### PR TITLE
checkpoint+cache fix

### DIFF
--- a/experiments/utils/checkpointing.py
+++ b/experiments/utils/checkpointing.py
@@ -304,9 +304,9 @@ class WandbSelectiveCheckpointUploader(pl_callbacks.Callback):
             print(msg)
             raise RuntimeError(msg)
         if not os.path.isfile(path):
-            msg = f"[checkpoint/upload][error] Path is not a file: '{path}' for alias='{alias}'"
+            msg = f"[checkpoint/upload][warn] Path is not a file (maybe pruned already): '{path}' for alias='{alias}'"
             print(msg)
-            raise RuntimeError(msg)
+            return
         # Compute hash and skip if identical content already uploaded for this alias
         try:
             file_hash = self._file_sha256(path)
@@ -335,26 +335,34 @@ class WandbSelectiveCheckpointUploader(pl_callbacks.Callback):
             api = wandb.Api()
             entity = getattr(run, "entity", None)
             project = getattr(run, "project", None)
+            versions = []
             if entity and project:
-                art_type = api.artifact_type(project=project, type_name="model")
-                collection = art_type.collection(artifact_name)
-                # In W&B public API, versions are iterated via `.artifacts()` on the collection
-                versions = list(collection.artifacts())
-                print(
-                    f"[checkpoint/prune] Using collection for {entity}/{project}:{artifact_name} → {len(versions)} versions"
-                )
-            else:
-                versions = []
+                locator = f"{entity}/{project}/{artifact_name}"
+                try:
+                    versions = list(api.artifact_versions("model", locator))
+                    print(
+                        f"[checkpoint/prune] Using artifact_versions for {locator} → {len(versions)} versions"
+                    )
+                except Exception as e:
+                    print(
+                        f"[checkpoint/prune][warn] artifact_versions lookup failed for {locator}: {e}."
+                    )
 
             # Fallback: use artifacts visible from this run only
             if not versions:
-                # run.logged_artifacts() returns artifact names like '<collection>:vN'; match by collection prefix
-                versions = [
-                    a
-                    for a in run.logged_artifacts()
-                    if isinstance(getattr(a, "name", None), str) and a.name.split(":", 1)[0] == artifact_name
-                ]
-                print(f"[checkpoint/prune] Fallback to run.logged_artifacts() → {len(versions)} versions")
+                api_run = None
+                if entity and project:
+                    try:
+                        api_run = api.run(f"{entity}/{project}/{run.id}")
+                    except Exception as e:
+                        print(f"[checkpoint/prune][warn] api.run lookup failed for {run.id}: {e}.")
+                if api_run is not None:
+                    versions = [
+                        a
+                        for a in api_run.logged_artifacts()
+                        if isinstance(getattr(a, "name", None), str) and a.name.split(":", 1)[0] == artifact_name
+                    ]
+                print(f"[checkpoint/prune] Fallback to logged_artifacts() → {len(versions)} versions")
 
             if len(versions) <= self.keep_last_k_versions:
                 print(f"[checkpoint/prune] Nothing to prune (have {len(versions)} ≤ keep {self.keep_last_k_versions})")

--- a/nvsubquadratic/modules/hyena_nd.py
+++ b/nvsubquadratic/modules/hyena_nd.py
@@ -106,9 +106,10 @@ class Hyena(torch.nn.Module):
         if key in self._rope1d_cache:
             return self._rope1d_cache[key]
         # If not in cache, compute and cache
-        with torch.no_grad():
-            cos, sin = rope.construct_rope_1d_cache_bhl(seq_len, dim, device, dtype, self.rope_base)
-            self._rope1d_cache[key] = (cos, sin)
+        with torch.inference_mode(False):
+            with torch.no_grad():
+                cos, sin = rope.construct_rope_1d_cache_bhl(seq_len, dim, device, dtype, self.rope_base)
+                self._rope1d_cache[key] = (cos, sin)
         return cos, sin
 
     def _rope_cache_2d(
@@ -136,11 +137,12 @@ class Hyena(torch.nn.Module):
         if key in self._rope2d_cache:
             return self._rope2d_cache[key]
         # If not in cache, compute and cache
-        with torch.no_grad():
-            cos_y, sin_y, cos_x, sin_x = rope.construct_rope_2d_cache_bhl(
-                height, width, dim_half, device, dtype, self.rope_base
-            )
-            self._rope2d_cache[key] = (cos_y, sin_y, cos_x, sin_x)
+        with torch.inference_mode(False):
+            with torch.no_grad():
+                cos_y, sin_y, cos_x, sin_x = rope.construct_rope_2d_cache_bhl(
+                    height, width, dim_half, device, dtype, self.rope_base
+                )
+                self._rope2d_cache[key] = (cos_y, sin_y, cos_x, sin_x)
         return cos_y, sin_y, cos_x, sin_x
 
     def _rope_cache_3d(
@@ -170,11 +172,12 @@ class Hyena(torch.nn.Module):
         if key in self._rope3d_cache:
             return self._rope3d_cache[key]
         # If not in cache, compute and cache
-        with torch.no_grad():
-            cos_z, sin_z, cos_y, sin_y, cos_x, sin_x = rope.construct_rope_3d_cache_bhl(
-                depth, height, width, dim_third, device, dtype, self.rope_base
-            )
-            self._rope3d_cache[key] = (cos_z, sin_z, cos_y, sin_y, cos_x, sin_x)
+        with torch.inference_mode(False):
+            with torch.no_grad():
+                cos_z, sin_z, cos_y, sin_y, cos_x, sin_x = rope.construct_rope_3d_cache_bhl(
+                    depth, height, width, dim_third, device, dtype, self.rope_base
+                )
+                self._rope3d_cache[key] = (cos_z, sin_z, cos_y, sin_y, cos_x, sin_x)
         return cos_z, sin_z, cos_y, sin_y, cos_x, sin_x
 
     def forward(

--- a/nvsubquadratic/modules/kernels_nd.py
+++ b/nvsubquadratic/modules/kernels_nd.py
@@ -67,8 +67,10 @@ class RandomFourierPositionalEmbeddingND(torch.nn.Module):
 
         # Construct grid cache (cube) of size 2 * L_cache - 1.
         # TODO(@dwromero): We must make sure that the grid_cache is kept in float32.
-        t = torch.linspace(-1, 1, 2 * self.L_cache - 1, dtype=torch.float32)
-        grid_cache = rearrange(torch.stack(torch.meshgrid(*[t] * data_dim, indexing="ij"), dim=-1), "... -> 1 ...")
+        with torch.inference_mode(False):
+            with torch.no_grad():
+                t = torch.linspace(-1, 1, 2 * self.L_cache - 1, dtype=torch.float32)
+                grid_cache = rearrange(torch.stack(torch.meshgrid(*[t] * data_dim, indexing="ij"), dim=-1), "... -> 1 ...")
         self.register_buffer("grid_cache", grid_cache, persistent=False)
 
         # Save the step size for the cache, so that subsequent calls keep equal distances between the elements of the cache grid.
@@ -103,14 +105,16 @@ class RandomFourierPositionalEmbeddingND(torch.nn.Module):
 
         # If the sequence is longer than the cache, create a new grid cache.
         if self.L_cache < seq_len:
-            max_limit = 1.0 + self.step_size * (seq_len - self.L_cache)
-            t = torch.linspace(
-                -max_limit, max_limit, 2 * seq_len - 1, device=self.grid_cache.device, dtype=torch.float32
-            )
-            self.grid_cache = rearrange(
-                torch.stack(torch.meshgrid(*[t] * self.data_dim, indexing="ij"), dim=-1), "... -> 1 ..."
-            )
-            self.L_cache = seq_len
+            with torch.inference_mode(False):
+                with torch.no_grad():
+                    max_limit = 1.0 + self.step_size * (seq_len - self.L_cache)
+                    t = torch.linspace(
+                        -max_limit, max_limit, 2 * seq_len - 1, device=self.grid_cache.device, dtype=torch.float32
+                    )
+                    self.grid_cache = rearrange(
+                        torch.stack(torch.meshgrid(*[t] * self.data_dim, indexing="ij"), dim=-1), "... -> 1 ..."
+                    )
+                    self.L_cache = seq_len
 
         # Ensure that the cached positions tensor has the correct data type.
         assert self.grid_cache.dtype == torch.float32, (
@@ -305,8 +309,10 @@ class SIRENPositionalEmbeddingND(torch.nn.Module):
         _init_siren_weights(self.linear, is_first_layer=True, w0=self.omega_0)
 
         # Construct grid cache (cube) of size 2 * L_cache - 1.
-        t = torch.linspace(-1, 1, 2 * self.L_cache - 1, dtype=torch.float32)
-        grid_cache = rearrange(torch.stack(torch.meshgrid(*[t] * data_dim, indexing="ij"), dim=-1), "... -> 1 ...")
+        with torch.inference_mode(False):
+            with torch.no_grad():
+                t = torch.linspace(-1, 1, 2 * self.L_cache - 1, dtype=torch.float32)
+                grid_cache = rearrange(torch.stack(torch.meshgrid(*[t] * data_dim, indexing="ij"), dim=-1), "... -> 1 ...")
         self.register_buffer("grid_cache", grid_cache, persistent=False)
 
         # Save the step size for the cache, so that subsequent calls keep equal distances between the elements of the cache grid.
@@ -341,15 +347,17 @@ class SIRENPositionalEmbeddingND(torch.nn.Module):
 
         # If the sequence is longer than the cache, create a new grid cache.
         if self.L_cache < seq_len:
-            max_limit = 1.0 + self.step_size * (seq_len - self.L_cache)
-            t = torch.linspace(
-                -max_limit, max_limit, 2 * seq_len - 1, device=self.grid_cache.device, dtype=torch.float32
-            )
+            with torch.inference_mode(False):
+                with torch.no_grad():
+                    max_limit = 1.0 + self.step_size * (seq_len - self.L_cache)
+                    t = torch.linspace(
+                        -max_limit, max_limit, 2 * seq_len - 1, device=self.grid_cache.device, dtype=torch.float32
+                    )
 
-            self.grid_cache = rearrange(
-                torch.stack(torch.meshgrid(*[t] * self.data_dim, indexing="ij"), dim=-1), "... -> 1 ..."
-            )
-            self.L_cache = seq_len
+                    self.grid_cache = rearrange(
+                        torch.stack(torch.meshgrid(*[t] * self.data_dim, indexing="ij"), dim=-1), "... -> 1 ..."
+                    )
+                    self.L_cache = seq_len
 
         # Ensure that the cached positions tensor has the correct data type.
         assert self.grid_cache.dtype == torch.float32, (

--- a/nvsubquadratic/ops/circular_fftconv.py
+++ b/nvsubquadratic/ops/circular_fftconv.py
@@ -102,9 +102,11 @@ class _PhaseRampCache1D:
             self._cache.move_to_end(key)
             return phase
 
-        f = torch.fft.rfftfreq(L, d=1.0, device=device, dtype=real_dtype)  # [Lf]
-        phases = -2.0 * math.pi * (s * f)  # [Lf]
-        phase = torch.complex(torch.cos(phases), torch.sin(phases))
+        with torch.inference_mode(False):
+            with torch.no_grad():
+                f = torch.fft.rfftfreq(L, d=1.0, device=device, dtype=real_dtype)  # [Lf]
+                phases = -2.0 * math.pi * (s * f)  # [Lf]
+                phase = torch.complex(torch.cos(phases), torch.sin(phases))
         self._cache[key] = phase
         if len(self._cache) > self.maxsize:
             self._cache.popitem(last=False)
@@ -183,11 +185,13 @@ class _PhaseRampCache2D:
             self._cache.move_to_end(key)
             return phase
 
-        fx = torch.fft.fftfreq(X, d=1.0, device=device, dtype=real_dtype)  # [X]
-        fy = torch.fft.rfftfreq(Y, d=1.0, device=device, dtype=real_dtype)  # [Y//2+1]
-        phases = -2.0 * math.pi * (sx * fx[:, None] + sy * fy[None, :])  # [X, Yf]
-        # Build complex phase e^{i*phases}
-        phase = torch.complex(torch.cos(phases), torch.sin(phases))
+        with torch.inference_mode(False):
+            with torch.no_grad():
+                fx = torch.fft.fftfreq(X, d=1.0, device=device, dtype=real_dtype)  # [X]
+                fy = torch.fft.rfftfreq(Y, d=1.0, device=device, dtype=real_dtype)  # [Y//2+1]
+                phases = -2.0 * math.pi * (sx * fx[:, None] + sy * fy[None, :])  # [X, Yf]
+                # Build complex phase e^{i*phases}
+                phase = torch.complex(torch.cos(phases), torch.sin(phases))
         # Insert + evict LRU
         self._cache[key] = phase
         if len(self._cache) > self.maxsize:
@@ -273,11 +277,15 @@ class _PhaseRampCache3D:
             self._cache.move_to_end(key)
             return phase
 
-        fx = torch.fft.fftfreq(X, d=1.0, device=device, dtype=real_dtype)  # [X]
-        fy = torch.fft.fftfreq(Y, d=1.0, device=device, dtype=real_dtype)  # [Y]
-        fz = torch.fft.rfftfreq(Z, d=1.0, device=device, dtype=real_dtype)  # [Zf]
-        phases = -2.0 * math.pi * (sx * fx[:, None, None] + sy * fy[None, :, None] + sz * fz[None, None, :])
-        phase = torch.complex(torch.cos(phases), torch.sin(phases))  # [X, Y, Zf]
+        with torch.inference_mode(False):
+            with torch.no_grad():
+                fx = torch.fft.fftfreq(X, d=1.0, device=device, dtype=real_dtype)  # [X]
+                fy = torch.fft.fftfreq(Y, d=1.0, device=device, dtype=real_dtype)  # [Y]
+                fz = torch.fft.rfftfreq(Z, d=1.0, device=device, dtype=real_dtype)  # [Zf]
+                phases = -2.0 * math.pi * (
+                    sx * fx[:, None, None] + sy * fy[None, :, None] + sz * fz[None, None, :]
+                )
+                phase = torch.complex(torch.cos(phases), torch.sin(phases))  # [X, Y, Zf]
         self._cache[key] = phase
         if len(self._cache) > self.maxsize:
             self._cache.popitem(last=False)


### PR DESCRIPTION
Fixed a couple bugs related to checkpointing where:

- wandb online storage would fill up because pruning failed when not logging to default entity
- starting from a checkpoint would throw an error because there were caches being built in inference_mode