### PR TITLE
fix: release wandb API client after pruning & add wandb_checkpoint_upload toggle

### DIFF
--- a/experiments/default_cfg.py
+++ b/experiments/default_cfg.py
@@ -44,6 +44,11 @@ class TrainerConfig:
     # Recommended: 2000-5000 for long runs to avoid losing progress on crashes.
     checkpoint_every_n_steps: Optional[int] = None
 
+    # Whether to upload checkpoints to W&B and run cache cleanup.
+    # Set to False to disable WandbSelectiveCheckpointUploader and WandbCacheCleanupCallback.
+    # Local ModelCheckpoint saving is unaffected by this flag.
+    wandb_checkpoint_upload: bool = True
+
 
 @dataclass
 class SchedulerConfig:

--- a/experiments/trainer.py
+++ b/experiments/trainer.py
@@ -88,7 +88,7 @@ def construct_trainer(
     user_callbacks = [instantiate(cb_cfg) for cb_cfg in cfg.callbacks] if cfg.callbacks else []
 
     callbacks_list = [
-        # Checkpoint callback
+        # Checkpoint callback (local saving — always enabled)
         checkpoint_callback,
         # Model summary callback
         pl_callbacks.ModelSummary(max_depth=-1),
@@ -98,25 +98,30 @@ def construct_trainer(
         pl_callbacks.Timer(),
         # Progress bar for SLURM/non-TTY environments - prints training progress with it/s
         pl_callbacks.TQDMProgressBar(refresh_rate=10),
-        # Wandb selective checkpoint uploader
-        WandbSelectiveCheckpointUploader(
-            upload_best=True,
-            upload_last=True,
-            remove_local_after_upload=False,
-            keep_last_k_versions=2,
-        ),
-        # Wandb cache cleanup callback to prevent W&B cache from growing too large (Disk Space OOM errors)
-        WandbCacheCleanupCallback(
-            max_cache_size="5GB",
-            every_n_epochs=2,
-            executable="wandb",
-            run_on_fit_start=True,
-            background=True,
-            timeout=60,
-        ),
         # Append user-defined callbacks
         *user_callbacks,
     ]
+
+    # Optionally add W&B checkpoint upload and cache cleanup callbacks
+    if cfg.trainer.wandb_checkpoint_upload:
+        callbacks_list.extend([
+            # Wandb selective checkpoint uploader
+            WandbSelectiveCheckpointUploader(
+                upload_best=True,
+                upload_last=True,
+                remove_local_after_upload=False,
+                keep_last_k_versions=2,
+            ),
+            # Wandb cache cleanup callback to prevent W&B cache from growing too large (Disk Space OOM errors)
+            WandbCacheCleanupCallback(
+                max_cache_size="5GB",
+                every_n_epochs=2,
+                executable="wandb",
+                run_on_fit_start=True,
+                background=True,
+                timeout=60,
+            ),
+        ])
 
     if cfg.train.run_start_time is not None and cfg.train.run_time_limit_hours is not None:
         callbacks_list.append(

--- a/experiments/utils/checkpointing.py
+++ b/experiments/utils/checkpointing.py
@@ -289,12 +289,14 @@ class WandbSelectiveCheckpointUploader(pl_callbacks.Callback):
         # Structure: {alias: last_sha256_hex}
         self._uploaded_hashes: dict[str, str] = {}
 
+
     def _file_sha256(self, path: str, chunk_size: int = 1024 * 1024) -> str:
         h = hashlib.sha256()
         with open(path, "rb") as f:
             for chunk in iter(lambda: f.read(chunk_size), b""):
                 h.update(chunk)
         return h.hexdigest()
+
 
     def _maybe_upload(self, run: "wandb.sdk.wandb_run.Run", path: str, alias: str):
         if not path:
@@ -432,6 +434,12 @@ class WandbSelectiveCheckpointUploader(pl_callbacks.Callback):
         except Exception as e:
             # Report errors explicitly but do not crash training
             print(f"[checkpoint/prune][error] {type(e).__name__}: {e}")
+        finally:
+            # Explicitly release the API client to free HTTP sessions/caches
+            try:
+                del api
+            except UnboundLocalError:
+                pass
 
     def on_validation_end(self, trainer: pl.Trainer, pl_module: pl.LightningModule) -> None:
         """Upload selected checkpoints at the end of validation if appropriate."""


### PR DESCRIPTION
- Add finally block to explicitly del wandb.Api() after _prune_old_versions to prevent HTTP session/cache accumulation over long training runs (OOM fix)
- Add wandb_checkpoint_upload flag to TrainerConfig (default: True) to allow disabling WandbSelectiveCheckpointUploader and WandbCacheCleanupCallback while keeping local ModelCheckpoint saving unaffected