### PR TITLE
FiLM parameterization, pos-embed conditioning & kernel visualization

### DIFF
--- a/examples/vit5_imagenet/v3/HYENA_ABLATION_TRACKER.md
+++ b/examples/vit5_imagenet/v3/HYENA_ABLATION_TRACKER.md
@@ -4,17 +4,18 @@ Goal: Close the 0.72pp gap between Hyena (81.45%) and Attention (82.17%).
 
 ## Baselines
 
-| Model                 | Best val/acc_ema | Peak Epoch | wandb ID | Status |
-| --------------------- | ---------------- | ---------- | -------- | ------ |
-| Attention v3          | 82.17%           | 751        | 44or24g1 | Done   |
-| Hyena v3 (omega_0=10) | 81.45%           | 639        | 5y0kxe8q | Done   |
+| Model                 | Peak val/acc_ema | Peak Epoch | Final (ep800) | wandb ID | Status |
+| --------------------- | ---------------- | ---------- | ------------- | -------- | ------ |
+| Attention v3          | 82.22%           | 743        | 82.09%        | 44or24g1 | Done   |
+| Hyena v3 (omega_0=10) | 81.45%           | 639        | 81.02%        | 5y0kxe8q | Done   |
+| FiLM-Hyena            | 81.83%           | 679        | 81.61%        | peeaqdkq | Done   |
 
 ## Tier 1a: Single-variable tests (launched in parallel)
 
-| #   | Name           | Hypothesis                | Override                            | SLURM Job | Node        | wandb ID | Best val/acc_ema  | Status  |
-| --- | -------------- | ------------------------- | ----------------------------------- | --------- | ----------- | -------- | ----------------- | ------- |
-| 2   | drop_path=0.15 | H2: regularization        | `net.block_cfg.drop_path_rate=0.15` | 33923     | b65c909e-19 | je5g     | 0.779 (ep435)     | RUNNING |
-| 5   | no pos_embed   | H4: absolute pos overfits | `net.use_pos_embed=False`           | 33910     | b65c909e-08 | 59fr     | **0.803** (ep487) | RUNNING |
+| #   | Name           | Hypothesis                | Override                            | SLURM Job | Node        | wandb ID | Peak val/acc_ema   | Final (ep800) | Status |
+| --- | -------------- | ------------------------- | ----------------------------------- | --------- | ----------- | -------- | ------------------ | ------------- | ------ |
+| 2   | drop_path=0.15 | H2: regularization        | `net.block_cfg.drop_path_rate=0.15` | 33923     | b65c909e-19 | qva7je5g | 0.8128 (ep739)     | 0.8120        | DONE   |
+| 5   | no pos_embed   | H4: absolute pos overfits | `net.use_pos_embed=False`           | 33910     | b65c909e-08 | bueo59fr | **0.8141** (ep643) | 0.8099        | DONE   |
 
 ## Tier 1b: Follow-up (launch after Tier 1a or when nodes free up)
 
@@ -22,14 +23,36 @@ Goal: Close the 0.72pp gap between Hyena (81.45%) and Attention (82.17%).
 | --- | ------------------- | ----------------- | ------------------------------------------------------------ | --------- | ----------- | -------- | ---------------- | ---------------------------------------------------- |
 | 1   | eta_min=4e-5        | H1: LR floor      | `scheduler.eta_min=4e-5`                                     | --        | --          | --       | --               | CANCELLED (low priority given overfitting diagnosis) |
 | 3   | eta_min + drop_path | H1+H2 combined    | `scheduler.eta_min=4e-5 net.block_cfg.drop_path_rate=0.1`    | --        | --          | --       | --               | CANCELLED (low priority)                             |
-| 4   | AdamW               | H3: LAMB mismatch | AdamW config (lr=1e-3, betas=0.9/0.95, wd=0.05, warmup=20ep) | 33980     | b65c909e-04 | 8amm     | 0.702 (ep128)    | RUNNING                                              |
+| 4   | AdamW               | H3: LAMB mismatch | AdamW config (lr=1e-3, betas=0.9/0.95, wd=0.05, warmup=20ep) | 33980     | b65c909e-04 | np4b8amm | 0.8005 (ep579)   | DONE (final 0.7893)                                  |
 
 ## Additional ablations
 
-| #   | Name            | Hypothesis                    | Override                                        | SLURM Job | Node        | wandb ID | Best val/acc_ema | Status  |
-| --- | --------------- | ----------------------------- | ----------------------------------------------- | --------- | ----------- | -------- | ---------------- | ------- |
-| 2b  | drop_path=0.1   | H2: lighter reg               | `net.block_cfg.drop_path_rate=0.1`              | 33979     | b65c909e-20 | e1lx     | 0.714 (ep132)    | RUNNING |
-| 6   | SIREN hidden WD | SIREN expressiveness overfits | `kernel_cfg.weight_decay_on_hidden_layers=True` | 33981     | b65c909e-06 | ys29     | 0.709 (ep125)    | RUNNING |
+| #   | Name            | Hypothesis                    | Override                                        | SLURM Job | Node        | wandb ID | Best val/acc_ema   | Status              |
+| --- | --------------- | ----------------------------- | ----------------------------------------------- | --------- | ----------- | -------- | ------------------ | ------------------- |
+| 2b  | drop_path=0.1   | H2: lighter reg               | `net.block_cfg.drop_path_rate=0.1`              | 33979     | b65c909e-20 | ine6e1lx | **0.8159** (ep699) | DONE (final 0.8143) |
+| 6   | SIREN hidden WD | SIREN expressiveness overfits | `kernel_cfg.weight_decay_on_hidden_layers=True` | 33981     | b65c909e-06 | hvnnys29 | 0.8077 (ep635)     | DONE (final 0.8011) |
+
+## Tier 1c: Schedule & LR experiments
+
+| #   | Name         | Hypothesis                         | Override                 | SLURM Job | Node        | wandb ID | Peak val/acc_ema | Status                                            |
+| --- | ------------ | ---------------------------------- | ------------------------ | --------- | ----------- | -------- | ---------------- | ------------------------------------------------- |
+| 11  | eta_min=1e-5 | H5: LR floor prevents late overfit | `scheduler.eta_min=1e-5` | 34069     | b65c909e-13 | 70i2uuvx | 0.8146 (ep647)   | DONE (final 0.8097, no improvement over baseline) |
+| 12  | LR=6e-3      | H6: higher LR → flatter minima     | `optimizer.lr=6e-3`      | 34070     | b65c909e-14 | o77wzn4w | 0.7835 (ep362)   | CANCELLED (underperforming)                       |
+| 13  | LR=5e-3      | H6b: moderate LR increase          | `optimizer.lr=5e-3`      | 34118     | b65c909e-04 | d7tsbmoj | 0.8135 (ep731)   | DONE (final 0.8116)                               |
+
+## Tier 1d: Combinations (based on drop_path=0.1 being best single-variable result)
+
+| #   | Name                    | Hypothesis                 | Override                                                   | SLURM Job | Node        | wandb ID | Peak val/acc_ema   | Status                            |
+| --- | ----------------------- | -------------------------- | ---------------------------------------------------------- | --------- | ----------- | -------- | ------------------ | --------------------------------- |
+| 14  | drop_path=0.1 + eta_min | Best reg + schedule fix    | `net.block_cfg.drop_path_rate=0.1 scheduler.eta_min=1e-5`  | 34119     | b65c909e-06 | 7py11egn | **0.8156** (ep791) | DONE (final 0.8151, best result!) |
+| 15  | drop_path=0.1 + no_pos  | Best reg + no absolute pos | `net.block_cfg.drop_path_rate=0.1 net.use_pos_embed=False` | 34120     | b65c909e-12 | wr6nl6no | 0.8140 (ep691)     | DONE (final 0.8129)               |
+
+## Tier 1e: Regularization fine-tuning & augmentation
+
+| #   | Name            | Hypothesis                             | Override                             | SLURM Job | Node        | wandb ID | Peak val/acc_ema | Status                                   |
+| --- | --------------- | -------------------------------------- | ------------------------------------ | --------- | ----------- | -------- | ---------------- | ---------------------------------------- |
+| 16  | drop_path=0.075 | Sweet spot between 0.05 and 0.1        | `net.block_cfg.drop_path_rate=0.075` | 34235     | b65c909e-42 | horchgti | 0.8149 (ep723)   | DONE (final 0.8136)                      |
+| 17  | smoothing=0.1   | Label smoothing (was 0.0, default 0.1) | `dataset.mixup_cfg.smoothing=0.1`    | 34286     | b65c909e-06 | 38kbg225 | 0.8141 (ep663)   | DONE (final 0.8089, worse than baseline) |
 
 ## Tier 2: Conditional on Tier 1 results
 
@@ -40,7 +63,43 @@ Goal: Close the 0.72pp gap between Hyena (81.45%) and Attention (82.17%).
 | 9   | RandAugment      | Augmentation      | DALI config change                      | --        | --   | --       | --               | PENDING |
 | 10  | RoPE             | Relative position | `use_rope=True`                         | --        | --   | --       | --               | PENDING |
 
-## Checkpoint analysis (run 5y0kxe8q)
+## Analysis
+
+### Peak vs final decay (finished runs, sorted by peak)
+
+| Run               | Peak       | Peak Ep | Final      | Decay       | Gap to Attn |
+| ----------------- | ---------- | ------- | ---------- | ----------- | ----------- |
+| Attention         | 82.22%     | 743     | 82.09%     | -0.13pp     | --          |
+| FiLM-Hyena        | 81.83%     | 679     | 81.61%     | -0.22pp     | -0.39pp     |
+| **dp0.1+eta_min** | **81.56%** | **791** | **81.51%** | **-0.04pp** | **-0.66pp** |
+| drop_path=0.1     | 81.59%     | 699     | 81.43%     | -0.16pp     | -0.63pp     |
+| drop_path=0.075   | 81.49%     | 723     | 81.36%     | -0.13pp     | -0.73pp     |
+| eta_min=1e-5      | 81.46%     | 647     | 80.97%     | -0.49pp     | -0.76pp     |
+| Hyena baseline    | 81.45%     | 639     | 81.02%     | -0.43pp     | -0.77pp     |
+| smoothing=0.1     | 81.41%     | 663     | 80.89%     | -0.53pp     | -0.81pp     |
+| dp0.1+no_pos      | 81.40%     | 691     | 81.29%     | -0.11pp     | -0.82pp     |
+| no pos_embed      | 81.41%     | 643     | 80.99%     | -0.42pp     | -0.81pp     |
+| LR=5e-3           | 81.35%     | 731     | 81.16%     | -0.19pp     | -0.87pp     |
+| drop_path=0.15    | 81.28%     | 739     | 81.20%     | -0.08pp     | -0.94pp     |
+| SIREN hidden WD   | 80.77%     | 635     | 80.11%     | -0.66pp     | -1.45pp     |
+| AdamW             | 80.05%     | 579     | 78.93%     | -1.12pp     | -2.17pp     |
+
+### Key findings
+
+- **Best combination**: dp0.1+eta_min — peak 81.56% (ep791), final 81.51%, only 0.04pp decay
+  - Peaks 152 epochs later than baseline; eta_min alone did nothing but combined with drop_path it works
+  - Best final accuracy of any Hyena ablation (81.51% vs baseline 81.02%)
+- **Best single-variable**: drop_path=0.1 — peak 81.59%, but more decay (0.16pp) and lower final (81.43%)
+- **eta_min=1e-5 alone ineffective**: needs regularization to have impact
+- **no_pos_embed adds nothing on top of drop_path=0.1**: dp0.1+no_pos ≈ dp0.1 alone
+- **Remaining gap to attention at peak**: 0.66pp (down from 0.77pp baseline)
+- **Remaining gap at final**: 0.58pp (down from 1.07pp baseline)
+- **drop_path=0.075**: 81.49%/81.36%, monotonically between dp=0.05 and dp=0.1 — confirms dp=0.1 is the sweet spot
+- **smoothing=0.1 hurts**: 81.41%/80.89%, *worse* decay than baseline (0.53pp vs 0.43pp). Label smoothing is counterproductive
+- **FiLM parameterization**: residual+identity+no_wd (run 20) stable at ep279, val/acc_ema=76.6%
+- **FiLM+pos_embed**: all 4 variants collapsed or had dead FiLM (see Tier 3 analysis)
+
+### Checkpoint analysis (run 5y0kxe8q)
 
 EMA weight drift from best (epoch 639) to latest (epoch 791) reveals:
 
@@ -49,9 +108,73 @@ EMA weight drift from best (epoch 639) to latest (epoch 791) reveals:
 - **QKV/MLP** drift 0.22-0.23x (all shrinking under WD)
 - Overfitting happens in standard ViT components, not SIREN
 
+## Tier 3: FiLM parameterization & pos-embed conditioning
+
+Refactored `KernelFiLMGenerator` to support configurable parameterization (`residual` vs `direct`),
+`no_weight_decay` flag, and initialization type (`identity` vs `small_random`).
+For `residual` mode, modulation is `(1 + gamma) * h + beta` (identity when gamma=0, beta=0).
+For `direct` mode, modulation is `gamma * h + beta` (identity when gamma=1, beta=0).
+
+### Standard FiLM (no pos-embed conditioning)
+
+| #   | Name              | Config                             | SLURM Job | wandb (v_num) | Epochs | Best loss | Status                                  |
+| --- | ----------------- | ---------------------------------- | --------- | ------------- | ------ | --------- | --------------------------------------- |
+| 18  | resid+small_rand  | residual, small_random init, no_wd | 34755     | w5op          | 35     | 3.99      | CANCELLED (loss spikes at ep15-17)      |
+| 19  | direct+nowd       | direct, identity init, no_wd       | 34756     | 38x3          | 31     | 6.28      | CANCELLED (re-launched with posemb)     |
+| 20  | **resid+id+nowd** | residual, identity init, no_wd     | 34813     | ziq3          | 279+   | 2.91      | **RUNNING** (val/acc_ema=76.6%, stable) |
+
+### Pos-embed FiLM conditioning (`film_on_pos_embed=True`)
+
+FiLM applied *before* sin() on the positional embedding: `sin(gamma * (Wx + b) + beta)`.
+This enables input-dependent spatial warping of the kernel coordinates.
+
+| #   | Name               | Config                                    | SLURM Job | wandb (v_num) | Epochs | Collapse ep | Status                                      |
+| --- | ------------------ | ----------------------------------------- | --------- | ------------- | ------ | ----------- | ------------------------------------------- |
+| 21  | resid+nowd+posemb  | residual, identity, no_wd, omega_0=10     | 34819     | rfv7          | 66     | ~17         | COLLAPSED (loss → 6.9)                      |
+| 22  | direct+nowd+posemb | direct, identity, no_wd, omega_0=10       | 34852     | bktk          | 3      | ~2          | COLLAPSED (loss → 6.8)                      |
+| 23  | resid+wd+posemb    | residual, identity, **wd ON**, omega_0=10 | 34855     | kufi          | 16     | --          | CANCELLED (stable but FiLM dead: weights=0) |
+| 24  | resid+nowd+omega1  | residual, identity, no_wd, **omega_0=1**  | 34860     | 06gv          | 16     | ~15         | COLLAPSED (delayed but same failure)        |
+
+### Pos-embed instability analysis
+
+**Root cause**: omega_0 amplification of gamma in the pre-sin FiLM.
+
+The pos-embed linear weights have omega_0 baked in (weights ~\[-30, +30\] for omega_0=10),
+producing pre-activation values in \[-52, +52\]. When FiLM applies `(1+gamma) * pre_act + beta`
+before `sin()`, gamma multiplies these large values:
+
+| gamma | pos-embed disruption (pre-sin) | hidden disruption (post-sin) | Amplification |
+| ----- | ------------------------------ | ---------------------------- | ------------- |
+| 0.01  | mean=0.073, max=0.49           | mean=0.006, max=0.01         | 12x / 49x     |
+| 0.05  | mean=0.350, max=1.89           | mean=0.032, max=0.05         | 11x / 38x     |
+| 0.10  | mean=0.611, max=1.99           | mean=0.063, max=0.10         | 10x / 20x     |
+
+A gamma of just 0.05 makes `sin()` output essentially random (max disruption 1.89/2.0).
+Hidden layers are unaffected because FiLM is applied *after* sin() on values in \[-1, 1\].
+
+**Collapse mechanism** (from checkpoint forensics, run 21):
+
+1. Init: gamma=0, beta=0 (identity). Weight norms ~2-3.
+1. Epoch 15 (pre-collapse): gamma std ~0.02-0.06. Already causing significant disruption.
+1. Positive feedback: disrupted sine → noisy gradients → weights grow faster → larger gamma.
+1. Post-collapse (epoch 63): gamma std 0.2-0.4, weight norms 12-24. Sine is random.
+
+**Weight decay (run 23)**: Prevents collapse by keeping output weights at exactly zero.
+Identity init + weight decay = dead zone: the FiLM never learns *anything*.
+
+**Reduced omega_0 (run 24)**: Delays collapse from epoch 2-3 to epoch 14-15 by reducing
+pre-activation magnitude ~10x, but the feedback loop still exists.
+
+**Conclusion**: Pre-sin FiLM on pos-embed is fundamentally unstable without hard bounds on gamma.
+Next experiments should explore: (a) tanh clamping of gamma/beta, or (b) moving FiLM to after
+sine in the pos-embed layer.
+
 ## Notes
 
 - All runs use `wandb.job_group=vit5_imagenet_hyena_ablation`
 - Base config: `examples/vit5_imagenet/v3/vit5_small_pretrain_hyena_cls_row_gated_ema.py`
+- FiLM base config: `examples/vit5_imagenet/v3/vit5_small_pretrain_hyena_cls_row_gated_film_ema.py`
+- Pos-embed config: `examples/vit5_imagenet/v3/vit5_small_pretrain_hyena_cls_row_gated_film_posemb_ema.py`
 - Code change for Run 5: `use_pos_embed` flag added to `ViT5ClassificationNet` (gates `pos_embed` allocation and forward add)
 - Code change for Run 6: `weight_decay_on_hidden_layers` flag added to `SIRENKernelND`
+- Code changes for Tier 3: Refactored `KernelFiLMGenerator` with `film_parameterization`, `no_weight_decay`, `init_type`, `init_std`; added `film_on_pos_embed` to `SIRENKernelND`

--- a/examples/vit5_imagenet/v3/vit5_small_pretrain_hyena_cls_row_gated_film_posemb_ema.py
+++ b/examples/vit5_imagenet/v3/vit5_small_pretrain_hyena_cls_row_gated_film_posemb_ema.py
@@ -1,14 +1,16 @@
-"""ViT-5-Small + Hyena ImageNet-1k pretrain — CLS-row, gated, FiLM-conditioned SIREN, EMA.
+"""ViT-5-Small + Hyena ImageNet-1k pretrain — CLS-row, gated, FiLM + pos-embed conditioning, EMA.
 
-Extends the gated Hyena config with input-dependent SIREN kernels via FiLM
-conditioning from register tokens.  Each ``ViT5ResidualBlock`` extracts
-register tokens from the normalized input, pools them via a learnable
-weighted average (``RegisterPooling``), and passes the conditioning vector
-through to the SIREN kernel generator where it modulates every hidden layer
-via FiLM (gamma * h + beta).
+Extends the FiLM config with input-dependent spatial warping: the first
+FiLM (gamma, beta) pair modulates the SIREN positional embedding output
+*before* it enters the hidden layers.  This lets the model learn
+input-dependent coordinate transforms — effectively warping the kernel's
+spatial structure based on the input.
 
-Only the FiLM/Hyena-specific network definition lives here; everything else
-(dataset, optimizer, scheduler, EMA, etc.) comes from ``_pretrain_base``.
+The remaining FiLM pairs modulate hidden activations as before, so this
+is strictly a superset of standard FiLM conditioning.
+
+Only the network definition lives here; everything else (dataset, optimizer,
+scheduler, EMA, etc.) comes from ``_pretrain_base``.
 
 CLS-row architecture: CLS + 13 registers as extra row -> 15x14 grid.
 Gated variant: SiLU first gate, Sigmoid second gate.
@@ -60,14 +62,14 @@ FILM_INIT_STD = 1e-4
 
 
 def get_config() -> ExperimentConfig:
-    """Return the ViT-5-Small + Hyena CLS-row gated + FiLM pretrain config with EMA."""
+    """Return the ViT-5-Small + Hyena CLS-row gated + FiLM + pos-embed pretrain config with EMA."""
     config = get_base_config()
     config.compile_compatible_fftconv = True
 
     film_cfg = LazyConfig(KernelFiLMGenerator)(
         cond_dim=HIDDEN_DIM,
         kernel_hidden_dim=KERNEL_MLP_HIDDEN_DIM,
-        num_film_layers=KERNEL_NUM_LAYERS - 1,
+        num_film_layers=KERNEL_NUM_LAYERS,  # +1 vs standard FiLM: extra pair for pos-embed
         film_hidden_dim=FILM_HIDDEN_DIM,
         film_parameterization=FILM_PARAMETERIZATION,
         no_weight_decay=FILM_NO_WEIGHT_DECAY,
@@ -92,6 +94,7 @@ def get_config() -> ExperimentConfig:
                     use_bias=True,
                     hidden_omega_0=KERNEL_HIDDEN_OMEGA_0,
                     film_cfg=film_cfg,
+                    film_on_pos_embed=True,
                 ),
                 mask_cfg=LazyConfig(torch.nn.Identity)(),
                 grid_type="double",

--- a/experiments/utils/cli.py
+++ b/experiments/utils/cli.py
@@ -210,6 +210,8 @@ def apply_config_overrides(config: ExperimentConfig, overrides: list[str]) -> Ex
                     value = True
                 elif value.lower() == "false":
                     value = False
+                elif value.lower() == "none":
+                    value = None
                 # Handle tuples: (x, y) or (x,y)
                 elif value.startswith("(") and value.endswith(")"):
                     try:

--- a/nvsubquadratic/modules/film.py
+++ b/nvsubquadratic/modules/film.py
@@ -7,9 +7,17 @@ Provides:
   conditioning vector per sample.
 """
 
+from __future__ import annotations
+
+from typing import Literal
+
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
+
+
+FiLMParameterization = Literal["residual", "direct"]
+FiLMInitType = Literal["identity", "small_random"]
 
 
 class KernelFiLMGenerator(nn.Module):
@@ -22,6 +30,24 @@ class KernelFiLMGenerator(nn.Module):
         kernel_hidden_dim: Hidden dimension of the SIREN layers to modulate.
         num_film_layers: Number of (gamma, beta) pairs to produce (one per SIREN hidden layer).
         film_hidden_dim: Hidden dimension of the FiLM generator MLP (bottleneck).
+        film_parameterization: How the FiLM modulation is applied:
+
+            - ``"residual"``: Modulation is ``(1 + gamma) * h + beta``; the +1 is
+              folded into gamma in :meth:`forward`.  Identity = gamma=0, beta=0.
+            - ``"direct"``: Modulation is ``gamma * h + beta``.
+              Identity = gamma=1, beta=0.
+        no_weight_decay: If True, all parameters are marked with ``_no_weight_decay``
+            to exclude them from the optimizer's weight decay group.
+        init_type: How the output layer of the MLP is initialized:
+
+            - ``"identity"``: Output weights=0, bias set to the identity point
+              for the chosen parameterization (bias=0 for residual, bias=(1,0)
+              for direct).  Exact identity at init.
+            - ``"small_random"``: Same bias as ``"identity"`` but with output
+              weights drawn from N(0, ``init_std``) to break symmetry.
+              Near-identity at init.
+        init_std: Standard deviation for output-layer weight init when
+            ``init_type="small_random"``.  Ignored for ``"identity"``.
     """
 
     def __init__(  # noqa: D107
@@ -30,10 +56,15 @@ class KernelFiLMGenerator(nn.Module):
         kernel_hidden_dim: int,
         num_film_layers: int,
         film_hidden_dim: int = 64,
+        film_parameterization: FiLMParameterization = "residual",
+        no_weight_decay: bool = False,
+        init_type: FiLMInitType = "small_random",
+        init_std: float = 1e-4,
     ):
         super().__init__()
         self.num_film_layers = num_film_layers
         self.kernel_hidden_dim = kernel_hidden_dim
+        self.residual = film_parameterization == "residual"
 
         out_dim = num_film_layers * 2 * kernel_hidden_dim
         self.mlp = nn.Sequential(
@@ -42,29 +73,42 @@ class KernelFiLMGenerator(nn.Module):
             nn.Linear(film_hidden_dim, out_dim),
         )
 
-        self._init_weights()
+        # Initialize the MLP output layer
+        self._init_weights(init_type, init_std)
 
-    def _init_weights(self):
-        """Initialize so that gamma ~1 and beta ~0 at the start (identity modulation).
+        # Mark parameters to be excluded from weight decay
+        if no_weight_decay:
+            for param in self.parameters():
+                param._no_weight_decay = True
 
-        The output layer weights are zeroed and biases set to (gamma=1, beta=0),
-        so at init the FiLM transform is the identity: ``1 * h + 0 = h``.  This
-        means the model starts as if FiLM conditioning does not exist and
-        gradually learns to modulate — a standard residual-style init pattern
-        (cf. ControlNet, DiT adaptive LayerNorm).
+    def _init_weights(self, init_type: FiLMInitType, init_std: float):
+        """Initialize the MLP output layer according to ``init_type``.
 
-        The first linear layer keeps PyTorch's default Kaiming init; its exact
-        values are irrelevant at init because they are multiplied by the
-        all-zeros output weight matrix.
+        The bias is always set to the identity point for the chosen
+        parameterization: zero for residual (since ``(1+0)*h+0 = h``),
+        or ``(gamma=1, beta=0)`` for direct (since ``1*h+0 = h``).
+
+        ``"small_random"`` additionally gives the output weights a small random
+        perturbation to break the zero-weight saddle point.
         """
         final_linear = self.mlp[-1]
-        nn.init.zeros_(final_linear.weight)
+
+        if init_type == "identity":
+            nn.init.zeros_(final_linear.weight)
+        elif init_type == "small_random":
+            nn.init.normal_(final_linear.weight, mean=0.0, std=init_std)
+        else:
+            raise ValueError(f"Unknown init_type: {init_type!r}. Expected 'identity' or 'small_random'.")
+
         with torch.no_grad():
             bias = final_linear.bias
-            for i in range(self.num_film_layers):
-                offset = i * 2 * self.kernel_hidden_dim
-                bias[offset : offset + self.kernel_hidden_dim].fill_(1.0)  # gamma -> 1
-                bias[offset + self.kernel_hidden_dim : offset + 2 * self.kernel_hidden_dim].fill_(0.0)  # beta -> 0
+            if self.residual:
+                bias.zero_()
+            else:
+                for i in range(self.num_film_layers):
+                    offset = i * 2 * self.kernel_hidden_dim
+                    bias[offset : offset + self.kernel_hidden_dim].fill_(1.0)
+                    bias[offset + self.kernel_hidden_dim : offset + 2 * self.kernel_hidden_dim].fill_(0.0)
 
     def forward(self, conditioning: torch.Tensor) -> list[tuple[torch.Tensor, torch.Tensor]]:
         """Generate FiLM parameters from the conditioning vector.
@@ -74,10 +118,15 @@ class KernelFiLMGenerator(nn.Module):
 
         Returns:
             List of (gamma, beta) tuples, each [B, kernel_hidden_dim].
+            Callers always apply ``gamma * h + beta``.  When using residual
+            parameterization, the +1 offset is already folded into gamma here.
         """
         out = self.mlp(conditioning)  # [B, num_film_layers * 2 * kernel_hidden_dim]
         chunks = out.chunk(self.num_film_layers, dim=-1)  # num_film_layers x [B, 2 * kernel_hidden_dim]
-        return [c.chunk(2, dim=-1) for c in chunks]  # list of (gamma, beta) tuples
+        pairs = [c.chunk(2, dim=-1) for c in chunks]  # list of (gamma, beta) tuples
+        if self.residual:
+            pairs = [(1 + gamma, beta) for gamma, beta in pairs]
+        return pairs
 
 
 class RegisterPooling(nn.Module):

--- a/nvsubquadratic/modules/kernels_nd.py
+++ b/nvsubquadratic/modules/kernels_nd.py
@@ -327,15 +327,23 @@ class SIRENPositionalEmbeddingND(torch.nn.Module):
         for param in self.parameters():
             param._no_weight_decay = True
 
-    def forward(self, seq_lens: tuple[int, ...]) -> tuple[torch.Tensor, torch.Tensor]:
+    def forward(
+        self,
+        seq_lens: tuple[int, ...],
+        film_params: tuple[torch.Tensor, torch.Tensor] | None = None,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
         """Computes the positional embeddings for a sequence of the given length.
 
         Args:
             seq_lens (tuple[int, ...]): Lengths of the input grid for which to compute the positional embeddings.
+            film_params: Optional (gamma, beta) pair, each [B, embedding_dim], applied
+                *before* the sine activation: ``sin(gamma * (W @ grid + b) + beta)``.
+                This modulates frequency (gamma) and phase (beta) of the positional
+                encoding, enabling input-dependent spatial warping.
 
         Returns:
             tuple:
-                - torch.Tensor: The positional embeddings, concatenated sine and cosine values (shape: [1, * spatial_dims, embedding_dim]).
+                - torch.Tensor: The positional embeddings, concatenated sine and cosine values (shape: [1|B, * spatial_dims, embedding_dim]).
                 - torch.Tensor: The input positions normalized between [-1, 1] (shape: [1, * spatial_dims, 1]).
 
         Raises:
@@ -389,6 +397,12 @@ class SIRENPositionalEmbeddingND(torch.nn.Module):
         else:
             out = self.linear(grid)
 
+        # Optionally apply FiLM before sine (spatial warping: frequency/phase modulation)
+        if film_params is not None:
+            gamma, beta = film_params
+            shape = [gamma.shape[0]] + [1] * self.data_dim + [gamma.shape[-1]]
+            out = gamma.view(*shape) * out + beta.view(*shape)
+
         # Apply sine activation in place.
         return out.sin_(), grid
 
@@ -415,6 +429,10 @@ class SIRENKernelND(torch.nn.Module):
             input-dependent FiLM conditioning of all hidden SIREN layers.
         weight_decay_on_hidden_layers: If True, apply weight decay to SIREN hidden layers.
             Default False preserves the original SIREN init by excluding them.
+        film_on_pos_embed: If True, the first FiLM (gamma, beta) pair modulates the
+            positional embedding output before it enters the hidden layers, enabling
+            input-dependent spatial warping of the kernel coordinates. Requires
+            ``embedding_dim == mlp_hidden_dim`` and one extra FiLM layer in ``film_cfg``.
     """
 
     def __init__(  # noqa: D107
@@ -430,6 +448,7 @@ class SIRENKernelND(torch.nn.Module):
         hidden_omega_0: float = 1.0,
         film_cfg: LazyConfig | None = None,
         weight_decay_on_hidden_layers: bool = False,
+        film_on_pos_embed: bool = False,
     ):
         super().__init__()
 
@@ -441,6 +460,12 @@ class SIRENKernelND(torch.nn.Module):
         self.omega_0 = float(omega_0)
         self.hidden_omega_0 = float(hidden_omega_0)
         self.L_cache = L_cache
+        self.film_on_pos_embed = film_on_pos_embed
+
+        if film_on_pos_embed:
+            assert embedding_dim == mlp_hidden_dim, (
+                f"film_on_pos_embed requires embedding_dim == mlp_hidden_dim, got {embedding_dim} != {mlp_hidden_dim}"
+            )
 
         # Construct positional embedding
         self.positional_embedding = SIRENPositionalEmbeddingND(
@@ -502,20 +527,25 @@ class SIRENKernelND(torch.nn.Module):
             tuple: (kernel, grid) where kernel has shape [1|B, *spatial, out_dim]
                 and grid has shape [1, *spatial, data_dim].
         """
-        # Generate positional embeddings and corresponding grid values
-        pos_emb, grid = self.positional_embedding(seq_lens)  # [1, *spatial, emb], [1, *spatial, data_dim]
-
         # Generate FiLM parameters if conditioning is available
         film_params = None
+        film_offset = 0
         if conditioning is not None and self.film_generator is not None:
             film_params = self.film_generator(conditioning)  # list of (gamma, beta), each [B, hidden_dim]
+
+        # Generate positional embeddings, optionally with FiLM before the sine
+        # (input-dependent spatial warping: frequency/phase modulation of coordinates)
+        pos_film = film_params[0] if (self.film_on_pos_embed and film_params is not None) else None
+        pos_emb, grid = self.positional_embedding(seq_lens, film_params=pos_film)
+        if pos_film is not None:
+            film_offset = 1
 
         # Forward through hidden layers with optional FiLM
         h = pos_emb
         for i, linear in enumerate(self.hidden_linears):
             h = self.sine(linear(h))
             if film_params is not None:
-                gamma, beta = film_params[i]
+                gamma, beta = film_params[i + film_offset]
                 # Reshape [B, hidden_dim] -> [B, 1, ..., 1, hidden_dim] for broadcasting over spatial dims
                 shape = [gamma.shape[0]] + [1] * self.data_dim + [gamma.shape[-1]]
                 gamma = gamma.view(*shape)

--- a/scripts/app_film_kernels.py
+++ b/scripts/app_film_kernels.py
@@ -1,0 +1,262 @@
+"""Interactive FiLM-Hyena kernel explorer (Streamlit).
+
+Loads pre-exported kernel data (.npz) and provides interactive controls
+to browse blocks, channels, and images.
+
+Usage:
+    streamlit run scripts/app_film_kernels.py
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import matplotlib.pyplot as plt
+import numpy as np
+import streamlit as st
+
+
+DATA_DIR = Path(__file__).resolve().parent.parent / "outputs" / "film_kernel_viz"
+DATASETS = {
+    "FiLM (original)": DATA_DIR / "kernel_data.npz",
+    "FiLM + pos_embed warping": DATA_DIR / "kernel_data_posemb.npz",
+}
+
+
+@st.cache_data
+def load_data(path: str):
+    """Load and unpack the .npz file into a structured dict."""
+    raw = np.load(path, allow_pickle=True)
+
+    labels = list(raw["labels"])
+    predictions = list(raw["predictions"])
+    thumbnails = raw["thumbnails"]  # [n_images, 112, 112, 3]
+
+    static, conditioned, reg_weights = {}, {}, {}
+    for b in range(12):
+        static[b] = raw[f"static_{b}"]  # [1, H, W, C]
+        conditioned[b] = raw[f"cond_{b}"]  # [n_images, H, W, C]
+        reg_weights[b] = raw[f"regw_{b}"]  # [13]
+
+    n_images = conditioned[0].shape[0]
+    spatial_h, spatial_w = conditioned[0].shape[1], conditioned[0].shape[2]
+    n_channels = conditioned[0].shape[3]
+
+    return {
+        "labels": labels,
+        "predictions": predictions,
+        "thumbnails": thumbnails,
+        "static": static,
+        "conditioned": conditioned,
+        "reg_weights": reg_weights,
+        "n_images": n_images,
+        "n_channels": n_channels,
+        "spatial_h": spatial_h,
+        "spatial_w": spatial_w,
+    }
+
+
+def make_heatmap(arr_2d: np.ndarray, vmin: float, vmax: float) -> np.ndarray:
+    """Convert a 2D array to an RGB image using RdBu_r colormap."""
+    cmap = plt.cm.RdBu_r
+    if vmax == vmin:
+        normed = np.full_like(arr_2d, 0.5)
+    else:
+        normed = (arr_2d - vmin) / (vmax - vmin)
+    normed = np.clip(normed, 0, 1)
+    rgba = cmap(normed)
+    return (rgba[:, :, :3] * 255).astype(np.uint8)
+
+
+def get_slice(kernel: np.ndarray, channel: int | None) -> np.ndarray:
+    """Extract a 2D slice from a kernel array.
+
+    kernel: [H, W, C] or [1, H, W, C]
+    Returns [H, W].
+    """
+    if kernel.ndim == 4:
+        kernel = kernel[0]
+    if channel is None:
+        return kernel.mean(axis=-1)
+    return kernel[:, :, channel]
+
+
+def main():
+    st.set_page_config(page_title="FiLM-Hyena Kernel Explorer", layout="wide")
+    st.title("FiLM-Hyena Kernel Explorer")
+
+    available = {name: p for name, p in DATASETS.items() if p.exists()}
+    if not available:
+        st.error("No data files found. Run `scripts/export_film_kernels.py` first.")
+        return
+
+    # ── Sidebar controls ─────────────────────────────────────────────────
+    with st.sidebar:
+        st.header("Controls")
+
+        dataset_name = st.selectbox("Model", list(available.keys()))
+        data = load_data(str(available[dataset_name]))
+
+        compare_mode = False
+        if len(available) > 1:
+            compare_mode = st.checkbox("Side-by-side comparison", value=False)
+            if compare_mode:
+                other_names = [n for n in available if n != dataset_name]
+                compare_name = st.selectbox("Compare with", other_names)
+                data_cmp = load_data(str(available[compare_name]))
+
+        block = st.slider("Block", 0, 11, 0)
+
+        use_mean = st.checkbox("Channel mean", value=True)
+        if use_mean:
+            channel = None
+        else:
+            channel = st.slider("Channel", 0, data["n_channels"] - 1, 0)
+
+        view_mode = st.radio("View mode", ["Conditioned", "Static", "Difference (Cond − Static)"])
+
+        st.markdown("---")
+        st.subheader(f"Register Weights (Block {block})")
+        fig_reg, ax_reg = plt.subplots(figsize=(4, 2.5))
+        w = data["reg_weights"][block]
+        colors = ["#d73027" if v == w.max() else "#4575b4" for v in w]
+        ax_reg.bar(range(len(w)), w, color=colors)
+        ax_reg.set_xlabel("Register")
+        ax_reg.set_ylabel("Weight")
+        ax_reg.set_xticks(range(len(w)))
+        ax_reg.set_ylim(0, min(1.0, w.max() * 1.2))
+        fig_reg.tight_layout()
+        st.pyplot(fig_reg)
+        plt.close(fig_reg)
+
+        st.caption(f"Max: reg {w.argmax()} ({w.max():.3f})")
+        entropy = -np.sum(w * np.log(w + 1e-10))
+        st.caption(f"Entropy: {entropy:.3f} / {np.log(len(w)):.3f}")
+
+    # ── Channel label ────────────────────────────────────────────────────
+    ch_label = "channel mean" if channel is None else f"channel {channel}"
+    st.markdown(f"**{dataset_name}** | **Block {block}** | **{ch_label}** | **{view_mode}**")
+
+    # ── Input image strip ────────────────────────────────────────────────
+    st.subheader("Input Images")
+    cols = st.columns(data["n_images"])
+    for i, col in enumerate(cols):
+        with col:
+            st.image(data["thumbnails"][i], caption=data["labels"][i], width=80)
+
+    # ── Helper to compute heatmaps from a data dict ──────────────────────
+    def compute_heatmaps(d):
+        s_slice = get_slice(d["static"][block], channel)
+        hms = []
+        for img_idx in range(d["n_images"]):
+            c_slice = get_slice(d["conditioned"][block][img_idx], channel)
+            if view_mode == "Conditioned":
+                hms.append(c_slice)
+            elif view_mode == "Static":
+                hms.append(s_slice)
+            else:
+                hms.append(c_slice - s_slice)
+        return hms, s_slice
+
+    def compute_color_range(hms):
+        all_vals = np.concatenate([h.ravel() for h in hms])
+        am = max(abs(all_vals.min()), abs(all_vals.max()), 1e-8)
+        return -am, am
+
+    def render_kernel_row(d, hms, vmin, vmax, label, s_slice):
+        """Render a single model's kernel heatmaps."""
+        if view_mode != "Static":
+            s_abs = max(abs(s_slice.min()), abs(s_slice.max()), 1e-8)
+            s_img = make_heatmap(s_slice, -s_abs, s_abs)
+            st.image(s_img, width=200, caption=f"Static kernel (max={s_abs:.5f})")
+
+        if view_mode == "Static":
+            s_abs = max(abs(s_slice.min()), abs(s_slice.max()), 1e-8)
+            s_img = make_heatmap(s_slice, -s_abs, s_abs)
+            st.image(s_img, width=300, caption=f"max={s_abs:.5f}")
+        else:
+            st.caption(f"Color range: [{vmin:.5f}, {vmax:.5f}]")
+            imgs_per_row = min(10, d["n_images"])
+            for row_start in range(0, d["n_images"], imgs_per_row):
+                row_end = min(row_start + imgs_per_row, d["n_images"])
+                cols = st.columns(row_end - row_start)
+                for i, col in enumerate(cols):
+                    idx = row_start + i
+                    img = make_heatmap(hms[idx], vmin, vmax)
+                    with col:
+                        st.image(img, caption=d["labels"][idx], use_container_width=True)
+
+    # ── Compute heatmaps ─────────────────────────────────────────────────
+    heatmaps, static_slice = compute_heatmaps(data)
+    vmin, vmax = compute_color_range(heatmaps)
+
+    if compare_mode:
+        heatmaps_cmp, static_slice_cmp = compute_heatmaps(data_cmp)
+        # Use shared color range for fair comparison
+        vmin_cmp, vmax_cmp = compute_color_range(heatmaps_cmp)
+        shared_abs = max(abs(vmin), abs(vmax), abs(vmin_cmp), abs(vmax_cmp))
+        vmin = vmin_cmp = -shared_abs
+        vmax = vmax_cmp = shared_abs
+
+        title = (
+            "Conditioned Kernels"
+            if view_mode == "Conditioned"
+            else ("Static Kernels" if view_mode == "Static" else "FiLM Effect (Cond − Static)")
+        )
+        st.subheader(title)
+
+        st.markdown(f"#### {dataset_name}")
+        render_kernel_row(data, heatmaps, vmin, vmax, dataset_name, static_slice)
+
+        st.markdown("---")
+        st.markdown(f"#### {compare_name}")
+        render_kernel_row(data_cmp, heatmaps_cmp, vmin_cmp, vmax_cmp, compare_name, static_slice_cmp)
+    else:
+        if view_mode != "Static":
+            st.subheader("Static Kernel (no FiLM)")
+            static_abs = max(abs(static_slice.min()), abs(static_slice.max()), 1e-8)
+            static_img = make_heatmap(static_slice, -static_abs, static_abs)
+            st.image(static_img, width=200, caption=f"max={static_abs:.5f}")
+
+        if view_mode == "Static":
+            st.subheader("Static Kernel (same for all images)")
+            static_abs = max(abs(static_slice.min()), abs(static_slice.max()), 1e-8)
+            static_img = make_heatmap(static_slice, -static_abs, static_abs)
+            st.image(static_img, width=300, caption=f"max={static_abs:.5f}")
+        else:
+            st.subheader(f"{'Conditioned Kernels' if view_mode == 'Conditioned' else 'FiLM Effect (Cond − Static)'}")
+            st.caption(f"Color range: [{vmin:.5f}, {vmax:.5f}]")
+            imgs_per_row = min(10, data["n_images"])
+            for row_start in range(0, data["n_images"], imgs_per_row):
+                row_end = min(row_start + imgs_per_row, data["n_images"])
+                cols = st.columns(row_end - row_start)
+                for i, col in enumerate(cols):
+                    idx = row_start + i
+                    img = make_heatmap(heatmaps[idx], vmin, vmax)
+                    with col:
+                        st.image(img, caption=data["labels"][idx], use_container_width=True)
+
+    # ── Stats ────────────────────────────────────────────────────────────
+    with st.expander("Channel statistics"):
+        cond_full = data["conditioned"][block]  # [n_images, H, W, C]
+        static_full = data["static"][block][0]  # [H, W, C]
+
+        diff_all = cond_full - static_full[None, ...]  # [n_images, H, W, C]
+        var_across_images = diff_all.var(axis=0).mean(axis=(0, 1))  # [C]
+
+        fig_var, ax_var = plt.subplots(figsize=(10, 3))
+        ax_var.bar(range(len(var_across_images)), var_across_images, width=1.0, color="#4575b4")
+        ax_var.set_xlabel("Channel")
+        ax_var.set_ylabel("FiLM effect variance")
+        ax_var.set_title(f"Block {block}: Per-channel variance of FiLM effect across {data['n_images']} images")
+        fig_var.tight_layout()
+        st.pyplot(fig_var)
+        plt.close(fig_var)
+
+        top_k = 10
+        top_channels = var_across_images.argsort()[::-1][:top_k]
+        st.markdown(f"**Top-{top_k} most varying channels:** {', '.join(str(c) for c in top_channels)}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/export_film_kernels.py
+++ b/scripts/export_film_kernels.py
@@ -1,0 +1,305 @@
+#!/usr/bin/env python
+"""Export FiLM-Hyena kernel data for interactive visualization.
+
+Downloads a checkpoint from W&B (or loads a local .ckpt), loads the FiLM-Hyena
+model (EMA weights), runs validation images through it, and saves all kernel
+data to a .npz file.
+
+Usage (inside srun):
+    # From W&B (default: original FiLM model):
+    srun --gres=gpu:1 ... bash -c '
+      source .env && conda activate nv-subq &&
+      PYTHONPATH=. python scripts/export_film_kernels.py'
+
+    # Local checkpoint with custom config:
+    srun --gres=gpu:1 ... bash -c '
+      source .env && conda activate nv-subq &&
+      PYTHONPATH=. python scripts/export_film_kernels.py \
+        --local-ckpt runs/.../checkpoints/last.ckpt \
+        --config examples.vit5_imagenet.v3.vit5_small_pretrain_hyena_cls_row_gated_film_posemb_ema \
+        --output outputs/film_kernel_viz/kernel_data_posemb.npz \
+        --use-ema'
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib
+import sys
+from pathlib import Path
+
+import numpy as np
+import torch
+import torch.nn.functional as F
+from PIL import Image
+from torchvision import transforms
+from torchvision.transforms import InterpolationMode
+
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(PROJECT_ROOT))
+
+from experiments.utils.checkpointing import (  # noqa: E402
+    align_compiled_keys,
+    download_checkpoint,
+    load_checkpoint_state_dict,
+)
+from nvsubquadratic.lazy_config import instantiate  # noqa: E402
+from nvsubquadratic.modules import rms_norm as _rms_norm_module  # noqa: E402
+from nvsubquadratic.modules.film import RegisterPooling  # noqa: E402
+from nvsubquadratic.modules.kernels_nd import SIRENKernelND  # noqa: E402
+
+
+def _rmsnorm_forward_safe(self, x: torch.Tensor) -> torch.Tensor:
+    """Pure-PyTorch RMSNorm forward (avoids quack stride-alignment errors)."""
+    input_dtype = x.dtype
+    x = x.to(torch.float32)
+    variance = x.pow(2).mean(-1, keepdim=True)
+    x = x * torch.rsqrt(variance + self.eps)
+    return (self.weight * x).to(input_dtype)
+
+
+_rms_norm_module.RMSNorm.forward = _rmsnorm_forward_safe
+
+# ── Defaults ─────────────────────────────────────────────────────────────────
+DEFAULT_WANDB_RUN_PATH = "implicit-long-convs/nvsubquadratic/peeaqdkq"
+DEFAULT_CHECKPOINT_ALIAS = "best"
+DEFAULT_CONFIG_MODULE = "examples.vit5_imagenet.v3.vit5_small_pretrain_hyena_cls_row_gated_film_ema"
+DEFAULT_OUTPUT = "outputs/film_kernel_viz/kernel_data.npz"
+
+IMAGENET_VAL_DIR = "/shared/data/image_datasets/imagenet_folder/val"
+NUM_IMAGES = 20
+
+IMAGENET_MEAN = [0.485, 0.456, 0.406]
+IMAGENET_STD = [0.229, 0.224, 0.225]
+IMAGE_SIZE = 224
+KERNEL_SEQ_LENS = (15, 14)
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description="Export FiLM-Hyena kernels")
+    parser.add_argument("--wandb-run", default=DEFAULT_WANDB_RUN_PATH, help="W&B run path (entity/project/run_id)")
+    parser.add_argument("--alias", default=DEFAULT_CHECKPOINT_ALIAS, help="W&B artifact alias (best/latest)")
+    parser.add_argument("--local-ckpt", default=None, help="Path to a local .ckpt file (skips W&B download)")
+    parser.add_argument("--config", default=DEFAULT_CONFIG_MODULE, help="Python config module path")
+    parser.add_argument("--output", default=DEFAULT_OUTPUT, help="Output .npz path (relative to project root)")
+    parser.add_argument("--use-ema", action="store_true", help="Load ema_network weights instead of network weights")
+    parser.add_argument("--num-images", type=int, default=NUM_IMAGES)
+    return parser.parse_args()
+
+
+def load_config(config_module: str):
+    mod = importlib.import_module(config_module)
+    return mod.get_config()
+
+
+def build_and_load_model(config, args):
+    network = instantiate(config.net)
+    network.eval()
+
+    if args.local_ckpt:
+        ckpt_path = args.local_ckpt
+        print(f"[info] Using local checkpoint: {ckpt_path}")
+    else:
+        ckpt_path = download_checkpoint(run_path=args.wandb_run, alias=args.alias)
+    raw_sd = load_checkpoint_state_dict(ckpt_path)
+    print(f"[info] Loaded state_dict ({len(raw_sd)} keys).")
+
+    net_prefix = "ema_network." if args.use_ema else "network."
+    compile_prefix = "_orig_mod."
+    sd = {}
+    for k, v in raw_sd.items():
+        if not k.startswith(net_prefix):
+            continue
+        key = k[len(net_prefix) :]
+        if key.startswith(compile_prefix):
+            key = key[len(compile_prefix) :]
+        sd[key] = v
+
+    if not sd:
+        raise ValueError(
+            f"No keys found with prefix '{net_prefix}'. Available prefixes: {{k.split('.')[0] for k in raw_sd.keys()}}"
+        )
+    print(f"[info] Extracted {len(sd)} keys with prefix '{net_prefix}'.")
+
+    sd = align_compiled_keys(sd, set(network.state_dict().keys()))
+    network.load_state_dict(sd, strict=True)
+    print("[info] Model loaded successfully.")
+    return network
+
+
+def get_val_transform():
+    return transforms.Compose(
+        [
+            transforms.Resize(IMAGE_SIZE, interpolation=InterpolationMode.BICUBIC),
+            transforms.CenterCrop(IMAGE_SIZE),
+            transforms.ToTensor(),
+            transforms.Normalize(mean=IMAGENET_MEAN, std=IMAGENET_STD),
+        ]
+    )
+
+
+def load_diverse_images(val_dir: str, n: int, transform):
+    val_path = Path(val_dir)
+    class_dirs = sorted([d for d in val_path.iterdir() if d.is_dir()])
+    step = max(1, len(class_dirs) // n)
+    selected_dirs = class_dirs[::step][:n]
+
+    images, labels, raw_images = [], [], []
+    for cls_dir in selected_dirs:
+        img_files = sorted([f for f in cls_dir.iterdir() if f.suffix.lower() in (".jpg", ".jpeg", ".png")])
+        if not img_files:
+            continue
+        img = Image.open(img_files[0]).convert("RGB")
+        images.append(transform(img))
+        labels.append(cls_dir.name)
+        # Save a thumbnail for display
+        thumb = img.resize((112, 112), Image.BICUBIC)
+        raw_images.append(np.array(thumb))
+
+    print(f"[info] Loaded {len(images)} images from classes: {labels}")
+    return images, labels, raw_images
+
+
+def get_siren_modules(network):
+    return [(name, mod) for name, mod in network.named_modules() if isinstance(mod, SIRENKernelND)]
+
+
+def get_register_pooling_modules(network):
+    return [(name, mod) for name, mod in network.named_modules() if isinstance(mod, RegisterPooling)]
+
+
+def extract_static_kernels(network, device):
+    siren_modules = get_siren_modules(network)
+    static = {}
+    for idx, (name, mod) in enumerate(siren_modules):
+        mod = mod.to(device)
+        with torch.no_grad():
+            kernel, _ = mod(KERNEL_SEQ_LENS, conditioning=None)
+        static[idx] = kernel.detach().cpu().numpy()
+        print(f"[static] Block {idx}: {kernel.shape}")
+    return static
+
+
+def extract_register_weights(network):
+    pooling_modules = get_register_pooling_modules(network)
+    weights = {}
+    for idx, (name, mod) in enumerate(pooling_modules):
+        logits = mod.logits.detach()
+        w = F.softmax(logits, dim=0).numpy()
+        weights[idx] = w
+        print(f"[regpool] Block {idx}: {w.shape}, max_reg={w.argmax()}, max_w={w.max():.3f}")
+    return weights
+
+
+class KernelCaptureHook:
+    def __init__(self):
+        self.kernels: dict[int, np.ndarray] = {}
+        self._handles = []
+
+    def register(self, network):
+        siren_modules = get_siren_modules(network)
+        for idx, (name, mod) in enumerate(siren_modules):
+            self._handles.append(mod.register_forward_hook(self._make_hook(idx)))
+        print(f"[hook] Registered {len(self._handles)} hooks.")
+
+    def _make_hook(self, block_idx):
+        def hook_fn(module, input, output):
+            kernel, _ = output
+            self.kernels[block_idx] = kernel.detach().cpu().numpy()
+
+        return hook_fn
+
+    def clear(self):
+        self.kernels.clear()
+
+    def remove_all(self):
+        for h in self._handles:
+            h.remove()
+        self._handles.clear()
+
+
+def run_inference(network, images, device):
+    hook = KernelCaptureHook()
+    hook.register(network)
+    network = network.to(device)
+    print(f"[infer] Running on device: {device}")
+
+    # conditioned[block_idx] will be a list of arrays, one per image
+    conditioned = {i: [] for i in range(12)}
+    predictions = []
+
+    for img_idx, img_tensor in enumerate(images):
+        hook.clear()
+        x = img_tensor.unsqueeze(0).to(device).permute(0, 2, 3, 1)
+
+        with torch.no_grad():
+            out = network({"input": x})
+
+        pred = out["logits"].argmax(dim=-1).item()
+        predictions.append(pred)
+
+        for block_idx, kernel_np in hook.kernels.items():
+            conditioned[block_idx].append(kernel_np)
+
+        print(f"[infer] Image {img_idx}: predicted class {pred}")
+
+    hook.remove_all()
+
+    # Stack: conditioned[block_idx] -> [n_images, H, W, out_dim]
+    for block_idx in conditioned:
+        conditioned[block_idx] = np.concatenate(conditioned[block_idx], axis=0)
+
+    return conditioned, predictions
+
+
+def main():
+    args = parse_args()
+    output_path = PROJECT_ROOT / args.output
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+
+    print("=" * 60)
+    print("FiLM-Hyena Kernel Data Export")
+    print(f"  config:  {args.config}")
+    print(f"  ckpt:    {args.local_ckpt or f'{args.wandb_run} ({args.alias})'}")
+    print(f"  ema:     {args.use_ema}")
+    print(f"  output:  {output_path}")
+    print("=" * 60)
+
+    print("\n[1/5] Loading config and model...")
+    config = load_config(args.config)
+    network = build_and_load_model(config, args)
+    device = "cuda" if torch.cuda.is_available() else "cpu"
+
+    print("\n[2/5] Loading validation images...")
+    transform = get_val_transform()
+    images, labels, thumbnails = load_diverse_images(IMAGENET_VAL_DIR, args.num_images, transform)
+
+    print("\n[3/5] Extracting static kernels...")
+    static_kernels = extract_static_kernels(network, device)
+
+    print("\n[4/5] Extracting register pooling weights...")
+    reg_weights = extract_register_weights(network)
+
+    print("\n[5/5] Running inference (conditioned kernels)...")
+    conditioned_kernels, predictions = run_inference(network, images, device)
+
+    # Pack into npz
+    data = {
+        "labels": np.array(labels),
+        "predictions": np.array(predictions),
+        "thumbnails": np.stack(thumbnails),  # [n_images, 112, 112, 3]
+    }
+    for block_idx in range(12):
+        data[f"static_{block_idx}"] = static_kernels[block_idx]  # [1, H, W, C]
+        data[f"cond_{block_idx}"] = conditioned_kernels[block_idx]  # [n_images, H, W, C]
+        data[f"regw_{block_idx}"] = reg_weights[block_idx]  # [13]
+
+    np.savez_compressed(str(output_path), **data)
+    file_size_mb = output_path.stat().st_size / 1e6
+    print(f"\nSaved to {output_path} ({file_size_mb:.1f} MB)")
+    print(f"Contents: {len(data)} arrays, {len(images)} images, 12 blocks")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/visualize_film_kernels.py
+++ b/scripts/visualize_film_kernels.py
@@ -1,0 +1,395 @@
+#!/usr/bin/env python
+"""Visualize input-dependent kernels produced by FiLM-Hyena.
+
+Downloads a checkpoint from W&B, loads the FiLM-Hyena model (EMA weights),
+runs a few ImageNet validation images through it with hooks on every
+SIRENKernelND, and produces three figure panels:
+
+  A. Static (unconditioned) SIREN kernels — no FiLM, per-block normalization.
+  B. Conditioned kernels per image — all 12 blocks, input images on top.
+  C. Difference maps (conditioned − static) — what FiLM adds, per image/block.
+
+Usage (inside an srun interactive job):
+    srun --gres=gpu:1 ... bash -c '
+      source .env && conda activate nv-subq &&
+      PYTHONPATH=. python scripts/visualize_film_kernels.py'
+"""
+
+from __future__ import annotations
+
+import importlib
+import sys
+from pathlib import Path
+
+import matplotlib.pyplot as plt
+import numpy as np
+import torch
+from PIL import Image
+from torchvision import transforms
+from torchvision.transforms import InterpolationMode
+
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(PROJECT_ROOT))
+
+from experiments.utils.checkpointing import (  # noqa: E402
+    align_compiled_keys,
+    download_checkpoint,
+    load_checkpoint_state_dict,
+)
+from nvsubquadratic.lazy_config import instantiate  # noqa: E402
+from nvsubquadratic.modules import rms_norm as _rms_norm_module  # noqa: E402
+from nvsubquadratic.modules.kernels_nd import SIRENKernelND  # noqa: E402
+
+
+def _rmsnorm_forward_safe(self, x: torch.Tensor) -> torch.Tensor:
+    """Pure-PyTorch RMSNorm forward (avoids quack stride-alignment errors)."""
+    input_dtype = x.dtype
+    x = x.to(torch.float32)
+    variance = x.pow(2).mean(-1, keepdim=True)
+    x = x * torch.rsqrt(variance + self.eps)
+    return (self.weight * x).to(input_dtype)
+
+
+_rms_norm_module.RMSNorm.forward = _rmsnorm_forward_safe
+
+# ── Config ───────────────────────────────────────────────────────────────────
+WANDB_RUN_PATH = "implicit-long-convs/nvsubquadratic/peeaqdkq"
+CHECKPOINT_ALIAS = "best"
+CONFIG_MODULE = "examples.vit5_imagenet.v3.vit5_small_pretrain_hyena_cls_row_gated_film_ema"
+IMAGENET_VAL_DIR = "/shared/data/image_datasets/imagenet_folder/val"
+NUM_IMAGES = 8
+OUTPUT_DIR = PROJECT_ROOT / "outputs" / "film_kernel_viz"
+
+IMAGENET_MEAN = [0.485, 0.456, 0.406]
+IMAGENET_STD = [0.229, 0.224, 0.225]
+IMAGE_SIZE = 224
+KERNEL_SEQ_LENS = (15, 14)  # CLS-row grid: 15 rows x 14 cols
+
+
+def load_config():
+    """Import and return the FiLM-Hyena ExperimentConfig."""
+    mod = importlib.import_module(CONFIG_MODULE)
+    return mod.get_config()
+
+
+def build_and_load_model(config):
+    """Build the network and load EMA weights from the W&B checkpoint."""
+    network = instantiate(config.net)
+    network.eval()
+
+    ckpt_path = download_checkpoint(run_path=WANDB_RUN_PATH, alias=CHECKPOINT_ALIAS)
+    raw_sd = load_checkpoint_state_dict(ckpt_path)
+    print(f"[info] Using EMA weights from 'state_dict' ({len(raw_sd)} keys).")
+
+    net_prefix = "network."
+    compile_prefix = "_orig_mod."
+    sd = {}
+    for k, v in raw_sd.items():
+        key = k
+        if key.startswith(net_prefix):
+            key = key[len(net_prefix) :]
+        if key.startswith(compile_prefix):
+            key = key[len(compile_prefix) :]
+        sd[key] = v
+
+    sd = align_compiled_keys(sd, set(network.state_dict().keys()))
+    network.load_state_dict(sd, strict=True)
+    print("[info] Model loaded successfully.")
+    return network
+
+
+def get_val_transform():
+    """Validation transform matching the DALI pipeline."""
+    return transforms.Compose(
+        [
+            transforms.Resize(IMAGE_SIZE, interpolation=InterpolationMode.BICUBIC),
+            transforms.CenterCrop(IMAGE_SIZE),
+            transforms.ToTensor(),
+            transforms.Normalize(mean=IMAGENET_MEAN, std=IMAGENET_STD),
+        ]
+    )
+
+
+def load_diverse_images(val_dir: str, n: int, transform):
+    """Load n images from evenly-spaced classes in the validation set."""
+    val_path = Path(val_dir)
+    class_dirs = sorted([d for d in val_path.iterdir() if d.is_dir()])
+    step = max(1, len(class_dirs) // n)
+    selected_dirs = class_dirs[::step][:n]
+
+    images, labels, paths = [], [], []
+    for cls_dir in selected_dirs:
+        img_files = sorted([f for f in cls_dir.iterdir() if f.suffix.lower() in (".jpg", ".jpeg", ".png")])
+        if not img_files:
+            continue
+        img_path = img_files[0]
+        img = Image.open(img_path).convert("RGB")
+        tensor = transform(img)
+        images.append(tensor)
+        labels.append(cls_dir.name)
+        paths.append(str(img_path))
+
+    print(f"[info] Loaded {len(images)} images from classes: {labels}")
+    return images, labels, paths
+
+
+# ── Kernel extraction ────────────────────────────────────────────────────────
+
+
+def get_siren_modules(network):
+    """Return an ordered list of (name, SIRENKernelND) from the network."""
+    return [(name, mod) for name, mod in network.named_modules() if isinstance(mod, SIRENKernelND)]
+
+
+def extract_static_kernels(network, device="cpu"):
+    """Call each SIRENKernelND directly with conditioning=None (no FiLM).
+
+    Returns:
+        dict[block_idx -> kernel tensor [1, H, W, out_dim]]
+    """
+    siren_modules = get_siren_modules(network)
+    static_kernels = {}
+    for idx, (name, mod) in enumerate(siren_modules):
+        mod = mod.to(device)
+        with torch.no_grad():
+            kernel, _grid = mod(KERNEL_SEQ_LENS, conditioning=None)
+        static_kernels[idx] = kernel.detach().cpu()
+        print(f"[static] Block {idx}: kernel shape {tuple(kernel.shape)}")
+    return static_kernels
+
+
+class KernelCaptureHook:
+    """Forward hook that captures SIRENKernelND outputs."""
+
+    def __init__(self):
+        self.kernels: dict[int, torch.Tensor] = {}
+        self._handles = []
+
+    def register(self, network):
+        """Register hooks on all SIRENKernelND modules."""
+        siren_modules = get_siren_modules(network)
+        for idx, (name, mod) in enumerate(siren_modules):
+            handle = mod.register_forward_hook(self._make_hook(idx))
+            self._handles.append(handle)
+            print(f"[hook] Registered on block {idx}: {name}")
+        print(f"[hook] Total hooks: {len(self._handles)}")
+
+    def _make_hook(self, block_idx):
+        def hook_fn(module, input, output):
+            kernel, grid = output
+            self.kernels[block_idx] = kernel.detach().cpu()
+
+        return hook_fn
+
+    def clear(self):
+        self.kernels.clear()
+
+    def remove_all(self):
+        for h in self._handles:
+            h.remove()
+        self._handles.clear()
+
+
+def run_inference(network, images, device="cpu"):
+    """Run each image through the model, capturing kernels per block per image."""
+    hook = KernelCaptureHook()
+    hook.register(network)
+    network = network.to(device)
+    print(f"[infer] Running on device: {device}")
+
+    all_kernels = {}
+    logits_list = []
+
+    for img_idx, img_tensor in enumerate(images):
+        hook.clear()
+        x = img_tensor.unsqueeze(0).to(device)
+        x = x.permute(0, 2, 3, 1)  # [1, H, W, C] channels-last
+
+        with torch.no_grad():
+            out = network({"input": x})
+
+        logits_list.append(out["logits"].cpu())
+        for block_idx, kernel in hook.kernels.items():
+            all_kernels[(block_idx, img_idx)] = kernel
+
+        pred = out["logits"].argmax(dim=-1).item()
+        print(f"[infer] Image {img_idx}: predicted class {pred}")
+
+    hook.remove_all()
+    return all_kernels, logits_list
+
+
+# ── Visualization helpers ────────────────────────────────────────────────────
+
+
+def kernel_to_heatmap(kernel: torch.Tensor) -> np.ndarray:
+    """Convert kernel [1, H, W, out_dim] to channel-mean heatmap [H, W]."""
+    return kernel[0].mean(dim=-1).numpy()
+
+
+def denorm_image(img_tensor: torch.Tensor) -> np.ndarray:
+    """Denormalize a [C, H, W] tensor to a [H, W, 3] uint8 numpy array."""
+    mean = torch.tensor(IMAGENET_MEAN).view(3, 1, 1)
+    std = torch.tensor(IMAGENET_STD).view(3, 1, 1)
+    img = img_tensor * std + mean
+    return img.clamp(0, 1).permute(1, 2, 0).numpy()
+
+
+def plot_panel_a(static_kernels, output_dir):
+    """Panel A: unconditioned SIREN kernels (no FiLM), per-block normalization."""
+    num_blocks = len(static_kernels)
+    rows, cols = 3, 4
+    fig, axes = plt.subplots(rows, cols, figsize=(20, 15))
+    fig.suptitle("Static SIREN Kernels (no FiLM conditioning, channel mean)", fontsize=18, y=0.98)
+
+    for block_idx in range(num_blocks):
+        r, c = divmod(block_idx, cols)
+        ax = axes[r][c]
+        hm = kernel_to_heatmap(static_kernels[block_idx])
+        abs_max = max(abs(hm.min()), abs(hm.max()))
+        abs_max = max(abs_max, 1e-8)
+        im = ax.imshow(hm, cmap="RdBu_r", vmin=-abs_max, vmax=abs_max, aspect="auto")
+        ax.set_title(f"Block {block_idx}  (max={abs_max:.4f})", fontsize=11)
+        ax.set_xticks([])
+        ax.set_yticks([])
+        fig.colorbar(im, ax=ax, shrink=0.8)
+
+    fig.tight_layout(rect=[0, 0, 1, 0.95])
+    out_path = output_dir / "panel_a_static_kernels.png"
+    fig.savefig(out_path, dpi=150, bbox_inches="tight")
+    plt.close(fig)
+    print(f"[save] Panel A -> {out_path}")
+
+
+def plot_panel_b(all_kernels, images, labels, output_dir):
+    """Panel B: conditioned kernels per image. Top row = input images, then 12 block rows."""
+    n_images = len(images)
+    num_blocks = max(b for (b, _) in all_kernels.keys()) + 1
+    n_rows = 1 + num_blocks  # image row + kernel rows
+
+    fig, axes = plt.subplots(n_rows, n_images, figsize=(3 * n_images, 2.5 * n_rows))
+    fig.suptitle("FiLM-Conditioned Kernels per Image (channel mean, per-block normalization)", fontsize=16, y=1.01)
+
+    # Top row: input images
+    for col in range(n_images):
+        ax = axes[0][col]
+        ax.imshow(denorm_image(images[col]))
+        ax.set_title(labels[col], fontsize=9)
+        ax.axis("off")
+
+    # Kernel rows
+    for block_idx in range(num_blocks):
+        row = block_idx + 1
+        row_heatmaps = []
+        for img_idx in range(n_images):
+            key = (block_idx, img_idx)
+            if key in all_kernels:
+                row_heatmaps.append(kernel_to_heatmap(all_kernels[key]))
+            else:
+                row_heatmaps.append(None)
+
+        valid = [h for h in row_heatmaps if h is not None]
+        abs_max = max((max(abs(h.min()), abs(h.max())) for h in valid), default=1.0)
+        abs_max = max(abs_max, 1e-8)
+
+        for col, hm in enumerate(row_heatmaps):
+            ax = axes[row][col]
+            if hm is not None:
+                ax.imshow(hm, cmap="RdBu_r", vmin=-abs_max, vmax=abs_max, aspect="auto")
+            if col == 0:
+                ax.set_ylabel(f"Block {block_idx}", fontsize=10)
+            ax.set_xticks([])
+            ax.set_yticks([])
+
+    fig.tight_layout()
+    out_path = output_dir / "panel_b_conditioned_kernels.png"
+    fig.savefig(out_path, dpi=150, bbox_inches="tight")
+    plt.close(fig)
+    print(f"[save] Panel B -> {out_path}")
+
+
+def plot_panel_c(all_kernels, static_kernels, images, labels, output_dir):
+    """Panel C: difference (conditioned - static) per image/block. Top row = images."""
+    n_images = len(images)
+    num_blocks = len(static_kernels)
+    n_rows = 1 + num_blocks
+
+    fig, axes = plt.subplots(n_rows, n_images, figsize=(3 * n_images, 2.5 * n_rows))
+    fig.suptitle(
+        "FiLM Effect: Conditioned − Static Kernel (channel mean, per-block normalization)", fontsize=16, y=1.01
+    )
+
+    # Top row: input images
+    for col in range(n_images):
+        ax = axes[0][col]
+        ax.imshow(denorm_image(images[col]))
+        ax.set_title(labels[col], fontsize=9)
+        ax.axis("off")
+
+    # Difference rows
+    for block_idx in range(num_blocks):
+        row = block_idx + 1
+        static_hm = kernel_to_heatmap(static_kernels[block_idx])
+
+        diff_heatmaps = []
+        for img_idx in range(n_images):
+            key = (block_idx, img_idx)
+            if key in all_kernels:
+                diff_heatmaps.append(kernel_to_heatmap(all_kernels[key]) - static_hm)
+            else:
+                diff_heatmaps.append(None)
+
+        valid = [d for d in diff_heatmaps if d is not None]
+        abs_max = max((max(abs(d.min()), abs(d.max())) for d in valid), default=1.0)
+        abs_max = max(abs_max, 1e-8)
+
+        for col, diff in enumerate(diff_heatmaps):
+            ax = axes[row][col]
+            if diff is not None:
+                ax.imshow(diff, cmap="RdBu_r", vmin=-abs_max, vmax=abs_max, aspect="auto")
+            if col == 0:
+                ax.set_ylabel(f"Block {block_idx}", fontsize=10)
+            ax.set_xticks([])
+            ax.set_yticks([])
+
+    fig.tight_layout()
+    out_path = output_dir / "panel_c_film_effect.png"
+    fig.savefig(out_path, dpi=150, bbox_inches="tight")
+    plt.close(fig)
+    print(f"[save] Panel C -> {out_path}")
+
+
+def main():
+    OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
+
+    print("=" * 60)
+    print("FiLM-Hyena Kernel Visualization")
+    print("=" * 60)
+
+    print("\n[1/5] Loading config and model...")
+    config = load_config()
+    network = build_and_load_model(config)
+
+    print("\n[2/5] Loading validation images...")
+    transform = get_val_transform()
+    images, labels, paths = load_diverse_images(IMAGENET_VAL_DIR, NUM_IMAGES, transform)
+
+    device = "cuda" if torch.cuda.is_available() else "cpu"
+
+    print("\n[3/5] Extracting static (unconditioned) kernels...")
+    static_kernels = extract_static_kernels(network, device=device)
+
+    print("\n[4/5] Running inference with kernel hooks...")
+    all_kernels, logits = run_inference(network, images, device=device)
+
+    print(f"\n[5/5] Generating visualizations ({len(all_kernels)} kernel snapshots)...")
+    plot_panel_a(static_kernels, OUTPUT_DIR)
+    plot_panel_b(all_kernels, images, labels, OUTPUT_DIR)
+    plot_panel_c(all_kernels, static_kernels, images, labels, OUTPUT_DIR)
+
+    print(f"\nDone! All figures saved to {OUTPUT_DIR}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- Refactor `KernelFiLMGenerator` with configurable parameterization (`residual`/`direct`), `no_weight_decay` flag, and initialization type (`identity`/`small_random`). The `(1+gamma)` logic is encapsulated inside the generator's `forward` method.
- Add `film_on_pos_embed` option to `SIRENKernelND` for input-dependent spatial warping of positional encodings before the sine activation.
- Add kernel visualization scripts (`export_film_kernels.py`, `visualize_film_kernels.py`, `app_film_kernels.py`) for inspecting FiLM-conditioned kernels.
- Update ablation tracker with Tier 3 experiments (runs 18-24): FiLM parameterization comparison and comprehensive pos-embed instability analysis.

## Key findings

- **Residual + identity init + no_weight_decay** (run 20) is stable and training well (ep279, val/acc_ema=76.6%).
- **Pre-sin FiLM on pos-embed is fundamentally unstable** without hard bounds: omega_0 amplifies gamma perturbations ~10-40x compared to hidden layers. A gamma of 0.05 makes `sin()` output essentially random.
- Weight decay prevents collapse but kills FiLM entirely (output weights stay at zero).
- Reducing omega_0 from 10 to 1 only delays collapse (ep2→ep15), doesn't prevent it.
- Next steps: explore tanh clamping of gamma or post-sin FiLM for the pos-embed layer.

## Test plan

- [x] Verified residual parameterization trains stably (run 20, 279+ epochs)
- [x] Verified direct parameterization trains stably (run 19, 31 epochs before manual cancel)
- [x] Confirmed identity init produces exact identity at initialization
- [x] Confirmed pos-embed instability via checkpoint forensics across 4 configurations

Made with [Cursor](https://cursor.com)