### PR TITLE
Add UNet and ViT5 general-purpose network architectures

### DIFF
--- a/examples/well/v1/MHD_64/cfg_unet_convnext.py
+++ b/examples/well/v1/MHD_64/cfg_unet_convnext.py
@@ -1,0 +1,127 @@
+"""UNet-ConvNeXt config for MHD_64 dataset.
+
+Magneto-hydrodynamic turbulence: 64x64x64 spatial resolution (3D), 7 fields.
+Uses the unified UNet with ConvNeXt blocks as baseline.
+"""
+
+import os
+
+import torch
+
+from experiments.datamodules.pde.well import WellDataModule
+from experiments.default_cfg import ExperimentConfig, SchedulerConfig, TrainConfig, WandbConfig
+from experiments.lightning_wrappers.well_lightning_wrapper import WELLRegressionWrapper
+from nvsubquadratic.lazy_config import LazyConfig
+from nvsubquadratic.networks.baselines.unet import ConvNeXtBlock, WellUNet
+
+
+PLACEHOLDER = None
+
+# Dataset parameters
+DATA_TYPE = "volume"
+DATA_DIM = 3
+WELL_BASE_PATH = os.environ.get("WELL_DATA_PATH", "./data/the_well")
+WELL_DATASET_NAME = "MHD_64"
+
+# Data parameters
+N_STEPS_INPUT = 4
+N_STEPS_OUTPUT = 1
+MAX_ROLLOUT_STEPS = 1
+
+N_FIELDS = 7
+N_CONSTANT_FIELDS = 0
+IN_CHANNELS = N_STEPS_INPUT * N_FIELDS + N_CONSTANT_FIELDS
+OUT_CHANNELS = N_FIELDS
+
+SPATIAL_RESOLUTION = (64, 64, 64)
+
+# UNet parameters
+BATCH_SIZE = 8
+INIT_FEATURES = 42
+BLOCKS_PER_STAGE = 2
+STAGES = 3  # 64 -> 32 -> 16 -> 8 (neck)
+BLOCKS_AT_NECK = 1
+GRADIENT_CHECKPOINTING = True  # 3D is memory-heavy
+
+# Training parameters
+TRAINING_ITERATIONS = 260_000
+WARMUP_ITERATIONS_PERCENTAGE = 0.1
+NUM_WORKERS = 8
+GRAD_CLIP = 1.0
+
+WEIGHT_DECAY = 1e-5
+LEARNING_RATE = 1e-3
+
+
+def get_config() -> ExperimentConfig:
+    """Returns the experiment configuration."""
+    config = ExperimentConfig()
+
+    config.debug = False
+    config.compile = False
+    config.compile_mode = "max-autotune-no-cudagraphs"
+
+    config.dataset = LazyConfig(WellDataModule)(
+        well_base_path=WELL_BASE_PATH,
+        well_dataset_name=WELL_DATASET_NAME,
+        batch_size=BATCH_SIZE,
+        num_workers=NUM_WORKERS,
+        use_normalization=True,
+        n_steps_input=N_STEPS_INPUT,
+        n_steps_output=N_STEPS_OUTPUT,
+        max_rollout_steps=MAX_ROLLOUT_STEPS,
+        min_dt_stride=1,
+        max_dt_stride=1,
+        local_staging_dir=None,
+    )
+
+    config.net = LazyConfig(WellUNet)(
+        dim_in=IN_CHANNELS,
+        dim_out=OUT_CHANNELS,
+        n_spatial_dims=DATA_DIM,
+        spatial_resolution=SPATIAL_RESOLUTION,
+        stages=STAGES,
+        blocks_per_stage=BLOCKS_PER_STAGE,
+        blocks_at_neck=BLOCKS_AT_NECK,
+        init_features=INIT_FEATURES,
+        block_cfg=LazyConfig(ConvNeXtBlock)(
+            n_spatial_dims=DATA_DIM,
+        ),
+        gradient_checkpointing=GRADIENT_CHECKPOINTING,
+    )
+
+    config.lightning_wrapper_class = LazyConfig(WELLRegressionWrapper)(
+        metadata=PLACEHOLDER,
+        n_steps_input=N_STEPS_INPUT,
+        n_steps_output=N_STEPS_OUTPUT,
+        max_rollout_steps=MAX_ROLLOUT_STEPS,
+        metric="MSE",
+    )
+
+    config.optimizer = LazyConfig(torch.optim.AdamW)(
+        params=PLACEHOLDER,
+        lr=LEARNING_RATE,
+        weight_decay=WEIGHT_DECAY,
+    )
+
+    config.train = TrainConfig(
+        batch_size="${dataset.batch_size}",
+        iterations=TRAINING_ITERATIONS,
+        grad_clip=GRAD_CLIP,
+        precision="bf16-mixed",
+    )
+
+    config.scheduler = SchedulerConfig(
+        name="cosine",
+        warmup_iterations_percentage=WARMUP_ITERATIONS_PERCENTAGE,
+        total_iterations="${train.iterations}",
+        mode="min",
+    )
+
+    config.wandb = WandbConfig(
+        entity="implicit-long-convs",
+        project="nvsubquadratic",
+        job_group="MHD_64_unet_convnext",
+    )
+
+    return config

--- a/examples/well/v1/MHD_64/cfg_unet_hyena.py
+++ b/examples/well/v1/MHD_64/cfg_unet_hyena.py
@@ -1,0 +1,140 @@
+"""UNet-Hyena config for MHD_64 dataset.
+
+Magneto-hydrodynamic turbulence: 64x64x64 spatial resolution (3D), 7 fields.
+Periodic boundary conditions -> circular FFT padding.
+
+Uses the unified UNet with Hyena blocks (gated global convolution via
+CKConvND with SIREN kernels + FFN).
+"""
+
+import os
+
+import torch
+
+from experiments.datamodules.pde.well import WellDataModule
+from experiments.default_cfg import ExperimentConfig, SchedulerConfig, TrainConfig, WandbConfig
+from experiments.lightning_wrappers.well_lightning_wrapper import WELLRegressionWrapper
+from nvsubquadratic.lazy_config import LazyConfig
+from nvsubquadratic.networks.baselines.unet import HyenaBlock, WellUNet
+
+
+PLACEHOLDER = None
+
+# Dataset parameters
+DATA_TYPE = "volume"
+DATA_DIM = 3
+WELL_BASE_PATH = os.environ.get("WELL_DATA_PATH", "./data/the_well")
+WELL_DATASET_NAME = "MHD_64"
+
+# Data parameters
+N_STEPS_INPUT = 4
+N_STEPS_OUTPUT = 1
+MAX_ROLLOUT_STEPS = 1
+
+N_FIELDS = 7
+N_CONSTANT_FIELDS = 0
+IN_CHANNELS = N_STEPS_INPUT * N_FIELDS + N_CONSTANT_FIELDS
+OUT_CHANNELS = N_FIELDS
+
+SPATIAL_RESOLUTION = (64, 64, 64)
+
+# UNet parameters
+BATCH_SIZE = 8
+INIT_FEATURES = 42
+BLOCKS_PER_STAGE = 2
+STAGES = 3  # 64 -> 32 -> 16 -> 8 (neck)
+BLOCKS_AT_NECK = 1
+MLP_RATIO = 4
+GRADIENT_CHECKPOINTING = True  # 3D is memory-heavy
+
+# Hyena / SIREN parameters
+OMEGA_0 = 100.0
+SIREN_LAYERS = 3
+SIREN_HIDDEN_DIM = 64
+
+# Training parameters
+TRAINING_ITERATIONS = 260_000
+WARMUP_ITERATIONS_PERCENTAGE = 0.1
+NUM_WORKERS = 8
+GRAD_CLIP = 1.0
+
+WEIGHT_DECAY = 1e-5
+LEARNING_RATE = 1e-3
+
+
+def get_config() -> ExperimentConfig:
+    """Returns the experiment configuration."""
+    config = ExperimentConfig()
+
+    config.debug = False
+    config.compile = True
+    config.compile_mode = "max-autotune-no-cudagraphs"
+
+    config.dataset = LazyConfig(WellDataModule)(
+        well_base_path=WELL_BASE_PATH,
+        well_dataset_name=WELL_DATASET_NAME,
+        batch_size=BATCH_SIZE,
+        num_workers=NUM_WORKERS,
+        use_normalization=True,
+        n_steps_input=N_STEPS_INPUT,
+        n_steps_output=N_STEPS_OUTPUT,
+        max_rollout_steps=MAX_ROLLOUT_STEPS,
+        min_dt_stride=1,
+        max_dt_stride=1,
+        local_staging_dir=None,
+    )
+
+    config.net = LazyConfig(WellUNet)(
+        dim_in=IN_CHANNELS,
+        dim_out=OUT_CHANNELS,
+        n_spatial_dims=DATA_DIM,
+        spatial_resolution=SPATIAL_RESOLUTION,
+        stages=STAGES,
+        blocks_per_stage=BLOCKS_PER_STAGE,
+        blocks_at_neck=BLOCKS_AT_NECK,
+        init_features=INIT_FEATURES,
+        block_cfg=LazyConfig(HyenaBlock)(
+            n_spatial_dims=DATA_DIM,
+            mlp_ratio=MLP_RATIO,
+            omega_0=OMEGA_0,
+            siren_layers=SIREN_LAYERS,
+            siren_hidden_dim=SIREN_HIDDEN_DIM,
+        ),
+        gradient_checkpointing=GRADIENT_CHECKPOINTING,
+    )
+
+    config.lightning_wrapper_class = LazyConfig(WELLRegressionWrapper)(
+        metadata=PLACEHOLDER,
+        n_steps_input=N_STEPS_INPUT,
+        n_steps_output=N_STEPS_OUTPUT,
+        max_rollout_steps=MAX_ROLLOUT_STEPS,
+        metric="MSE",
+    )
+
+    config.optimizer = LazyConfig(torch.optim.AdamW)(
+        params=PLACEHOLDER,
+        lr=LEARNING_RATE,
+        weight_decay=WEIGHT_DECAY,
+    )
+
+    config.train = TrainConfig(
+        batch_size="${dataset.batch_size}",
+        iterations=TRAINING_ITERATIONS,
+        grad_clip=GRAD_CLIP,
+        precision="bf16-mixed",
+    )
+
+    config.scheduler = SchedulerConfig(
+        name="cosine",
+        warmup_iterations_percentage=WARMUP_ITERATIONS_PERCENTAGE,
+        total_iterations="${train.iterations}",
+        mode="min",
+    )
+
+    config.wandb = WandbConfig(
+        entity="implicit-long-convs",
+        project="nvsubquadratic",
+        job_group="MHD_64_unet_hyena",
+    )
+
+    return config

--- a/examples/well/v1/MHD_64/cfg_vit5_attention.py
+++ b/examples/well/v1/MHD_64/cfg_vit5_attention.py
@@ -1,0 +1,189 @@
+"""MHD_64 ViT5-style 3D attention config.
+
+Uses ViT5Attention with 3D RoPE — frequencies split across Z/Y/X axes on the
+flat [B, T, C] sequence. No adapter needed: ViT5Attention handles 3D RoPE
+internally via precomputed buffers (CUDA-graph safe).
+
+Requires head_dim % 6 == 0 for 3D RoPE → NUM_HEADS=8, head_dim=48.
+"""
+
+import os
+
+import torch
+
+from experiments.datamodules.pde.well import WellDataModule
+from experiments.default_cfg import ExperimentConfig, SchedulerConfig, TrainConfig, WandbConfig
+from experiments.lightning_wrappers.well_lightning_wrapper import WELLRegressionWrapper
+from nvsubquadratic.lazy_config import LazyConfig
+from nvsubquadratic.modules.mlp import MLP
+from nvsubquadratic.modules.patchify import Patchify, Unpatchify
+from nvsubquadratic.modules.rms_norm import RMSNorm
+from nvsubquadratic.modules.vit5_attention import ViT5Attention
+from nvsubquadratic.modules.vit5_residual_block import ViT5ResidualBlock
+from nvsubquadratic.networks.vit5_general_purpose import ViT5GeneralPurposeNet
+from nvsubquadratic.utils.init import trunc_normal_init_factory
+
+
+PLACEHOLDER = None
+
+DATA_DIM = 3
+SPATIAL_SIZE = 64
+WELL_BASE_PATH = os.environ.get("WELL_DATA_PATH", "/gpfs/scratch1/shared/dwessels2/data/the_well/datasets")
+WELL_DATASET_NAME = "MHD_64"
+
+N_STEPS_INPUT = 4
+N_STEPS_OUTPUT = 1
+MAX_ROLLOUT_STEPS = 1
+
+N_FIELDS = 7
+N_CONSTANT_FIELDS = 0
+IN_CHANNELS = N_STEPS_INPUT * N_FIELDS + N_CONSTANT_FIELDS
+OUT_CHANNELS = N_FIELDS
+
+BATCH_SIZE = int(os.environ.get("MHD_VIT5_ATTN_BATCH_SIZE", 1))
+HIDDEN_DIM = int(os.environ.get("MHD_VIT5_ATTN_HIDDEN_DIM", 384))
+NUM_BLOCKS = int(os.environ.get("MHD_VIT5_ATTN_DEPTH", 12))
+PATCH_SIZE = int(os.environ.get("MHD_VIT5_ATTN_PATCH_SIZE", 8))
+NUM_HEADS = int(os.environ.get("MHD_VIT5_ATTN_NUM_HEADS", 8))  # head_dim=48, 48%6==0 for 3D RoPE
+NUM_REGISTERS = 14
+DROPOUT_RATE = 0.0
+DROP_PATH_RATE = 0.05
+LAYER_SCALE_INIT = 1e-4
+MLP_RATIO = 4.0
+
+TRAINING_ITERATIONS = 260_000
+WARMUP_ITERATIONS_PERCENTAGE = 0.1
+NUM_WORKERS = 8
+GRAD_CLIP = 1.0
+WEIGHT_DECAY = 1e-5
+LEARNING_RATE = 1e-4
+
+INIT_FN_FACTORY = trunc_normal_init_factory(std=0.02)
+
+
+def get_config() -> ExperimentConfig:
+    """Return the MHD_64 ViT5-style 3D attention config."""
+    config = ExperimentConfig()
+
+    config.debug = False
+    config.compile = True
+    config.compile_mode = "max-autotune"
+
+    config.dataset = LazyConfig(WellDataModule)(
+        well_base_path=WELL_BASE_PATH,
+        well_dataset_name=WELL_DATASET_NAME,
+        batch_size=BATCH_SIZE,
+        num_workers=NUM_WORKERS,
+        use_normalization=True,
+        n_steps_input=N_STEPS_INPUT,
+        n_steps_output=N_STEPS_OUTPUT,
+        max_rollout_steps=MAX_ROLLOUT_STEPS,
+        min_dt_stride=1,
+        max_dt_stride=1,
+        local_staging_dir=None,
+    )
+
+    patch_grid_size = SPATIAL_SIZE // PATCH_SIZE  # 8 per dimension
+
+    num_zero_pad = patch_grid_size**2 - NUM_REGISTERS  # 64 - 14 = 50, aligns prefix to one XY slice
+
+    mixer_cfg = LazyConfig(ViT5Attention)(
+        hidden_dim=HIDDEN_DIM,
+        num_heads=NUM_HEADS,
+        num_patches_h=patch_grid_size,
+        num_patches_w=patch_grid_size,
+        num_patches_d=patch_grid_size,
+        num_registers=NUM_REGISTERS,
+        use_cls_token=False,
+        prepend_registers=True,
+        num_zero_pad=num_zero_pad,
+        qk_norm=LazyConfig(RMSNorm)(dim=HIDDEN_DIM // NUM_HEADS, eps=1e-6),
+        rope_base=10000.0,
+        attn_dropout=0.0,
+        init_fn_qkv_proj=INIT_FN_FACTORY,
+        init_fn_out_proj=INIT_FN_FACTORY,
+    )
+
+    block_cfg = LazyConfig(ViT5ResidualBlock)(
+        sequence_mixer_cfg=mixer_cfg,
+        sequence_mixer_norm_cfg=LazyConfig(RMSNorm)(dim=HIDDEN_DIM, eps=1e-6),
+        mlp_cfg=LazyConfig(MLP)(
+            dim=HIDDEN_DIM,
+            activation="gelu",
+            expansion_factor=MLP_RATIO,
+            bias=False,
+            dropout_cfg=LazyConfig(torch.nn.Dropout)(p=DROPOUT_RATE),
+            init_method_in=INIT_FN_FACTORY,
+            init_method_out=INIT_FN_FACTORY,
+        ),
+        mlp_norm_cfg=LazyConfig(RMSNorm)(dim=HIDDEN_DIM, eps=1e-6),
+        hidden_dim=HIDDEN_DIM,
+        layer_scale_init=LAYER_SCALE_INIT,
+        drop_path_rate=DROP_PATH_RATE,
+    )
+
+    config.net = LazyConfig(ViT5GeneralPurposeNet)(
+        in_channels=IN_CHANNELS,
+        out_channels=OUT_CHANNELS,
+        hidden_dim=HIDDEN_DIM,
+        num_blocks=NUM_BLOCKS,
+        data_dim=DATA_DIM,
+        patch_size=PATCH_SIZE,
+        input_size=SPATIAL_SIZE,
+        num_registers=NUM_REGISTERS,
+        in_proj_cfg=LazyConfig(Patchify)(
+            in_features=PLACEHOLDER,
+            out_features=PLACEHOLDER,
+            data_dim=DATA_DIM,
+            patch_size=PATCH_SIZE,
+            stride=PATCH_SIZE,
+        ),
+        out_proj_cfg=LazyConfig(Unpatchify)(
+            in_features=PLACEHOLDER,
+            out_features=PLACEHOLDER,
+            data_dim=DATA_DIM,
+            patch_size=PATCH_SIZE,
+            stride=PATCH_SIZE,
+        ),
+        block_cfg=block_cfg,
+        norm_cfg=LazyConfig(RMSNorm)(dim=HIDDEN_DIM, eps=1e-6),
+        dropout_rate=DROPOUT_RATE,
+        use_cls_token=False,
+        prepend_registers=True,
+    )
+
+    config.lightning_wrapper_class = LazyConfig(WELLRegressionWrapper)(
+        metadata=PLACEHOLDER,
+        n_steps_input=N_STEPS_INPUT,
+        n_steps_output=N_STEPS_OUTPUT,
+        max_rollout_steps=MAX_ROLLOUT_STEPS,
+        metric="MSE",
+    )
+
+    config.optimizer = LazyConfig(torch.optim.AdamW)(
+        params=PLACEHOLDER,
+        lr=LEARNING_RATE,
+        weight_decay=WEIGHT_DECAY,
+    )
+
+    config.train = TrainConfig(
+        batch_size="${dataset.batch_size}",
+        iterations=TRAINING_ITERATIONS,
+        grad_clip=GRAD_CLIP,
+        precision="bf16-mixed",
+    )
+
+    config.scheduler = SchedulerConfig(
+        name="cosine",
+        warmup_iterations_percentage=WARMUP_ITERATIONS_PERCENTAGE,
+        total_iterations="${train.iterations}",
+        mode="min",
+    )
+
+    config.wandb = WandbConfig(
+        entity="implicit-long-convs",
+        project="nvsubquadratic",
+        job_group="MHD_64_vit5_attention_3d",
+    )
+
+    return config

--- a/examples/well/v1/MHD_64/cfg_vit5_hyena_3d.py
+++ b/examples/well/v1/MHD_64/cfg_vit5_hyena_3d.py
@@ -1,0 +1,230 @@
+"""MHD_64 ViT5-style 3D Hyena config with registers.
+
+Same approach as supernova_explosion_64/cfg_vit5_hyena_3d.py but for MHD_64 (7 fields).
+Uses ViT5HyenaAdapterND to reshape the flattened token sequence back to a 3D patch
+grid before applying Hyena. Preserves 3D spatial locality in the short conv (Conv3d)
+and SIREN kernel (data_dim=3).
+"""
+
+import os
+
+import torch
+
+from experiments.datamodules.pde.well import WellDataModule
+from experiments.default_cfg import ExperimentConfig, SchedulerConfig, TrainConfig, WandbConfig
+from experiments.lightning_wrappers.well_lightning_wrapper import WELLRegressionWrapper
+from nvsubquadratic.lazy_config import LazyConfig
+from nvsubquadratic.modules.ckconv_nd import CKConvND
+from nvsubquadratic.modules.hyena_nd import Hyena
+from nvsubquadratic.modules.kernels_nd import SIRENKernelND
+from nvsubquadratic.modules.mlp import MLP
+from nvsubquadratic.modules.patchify import Patchify, Unpatchify
+from nvsubquadratic.modules.rms_norm import RMSNorm
+from nvsubquadratic.modules.sequence_mixer import QKVSequenceMixer
+from nvsubquadratic.modules.vit5_hyena_adapter import ViT5HyenaAdapterND
+from nvsubquadratic.modules.vit5_residual_block import ViT5ResidualBlock
+from nvsubquadratic.networks.vit5_general_purpose import ViT5GeneralPurposeNet
+from nvsubquadratic.utils.init import trunc_normal_init_factory
+from nvsubquadratic.utils.qk_norm import L2Norm
+
+
+PLACEHOLDER = None
+
+DATA_DIM = 3
+SPATIAL_SIZE = 64
+WELL_BASE_PATH = os.environ.get("WELL_DATA_PATH", "/gpfs/scratch1/shared/dwessels2/data/the_well/datasets")
+WELL_DATASET_NAME = "MHD_64"
+
+N_STEPS_INPUT = 4
+N_STEPS_OUTPUT = 1
+MAX_ROLLOUT_STEPS = 1
+
+N_FIELDS = 7
+N_CONSTANT_FIELDS = 0
+IN_CHANNELS = N_STEPS_INPUT * N_FIELDS + N_CONSTANT_FIELDS
+OUT_CHANNELS = N_FIELDS
+
+BATCH_SIZE = int(os.environ.get("MHD_VIT5_HYENA3D_BATCH_SIZE", 8))
+HIDDEN_DIM = int(os.environ.get("MHD_VIT5_HYENA3D_HIDDEN_DIM", 384))
+NUM_BLOCKS = int(os.environ.get("MHD_VIT5_HYENA3D_DEPTH", 12))
+NUM_REGISTERS = 14
+DROPOUT_RATE = 0.0
+DROP_PATH_RATE = 0.05
+LAYER_SCALE_INIT = 1e-4
+MLP_RATIO = 4.0
+PATCH_SIZE = int(os.environ.get("MHD_VIT5_HYENA3D_PATCH_SIZE", 8))
+
+TRAINING_ITERATIONS = 260_000
+WARMUP_ITERATIONS_PERCENTAGE = 0.1
+NUM_WORKERS = 8
+GRAD_CLIP = 1.0
+
+WEIGHT_DECAY = 1e-5
+LEARNING_RATE = 1e-3
+
+KERNEL_MLP_HIDDEN_DIM = 32
+KERNEL_NUM_LAYERS = 3
+KERNEL_EMBEDDING_DIM = 32
+KERNEL_OMEGA_0 = 10.0
+KERNEL_HIDDEN_OMEGA_0 = 1.0
+
+INIT_FN_FACTORY = trunc_normal_init_factory(std=0.02)
+
+
+def get_config() -> ExperimentConfig:
+    """Return the MHD_64 ViT5-style 3D Hyena config."""
+    config = ExperimentConfig()
+
+    config.debug = False
+    config.compile = True
+    config.compile_mode = "max-autotune-no-cudagraphs"
+    config.compile_compatible_fftconv = True
+
+    config.dataset = LazyConfig(WellDataModule)(
+        well_base_path=WELL_BASE_PATH,
+        well_dataset_name=WELL_DATASET_NAME,
+        batch_size=BATCH_SIZE,
+        num_workers=NUM_WORKERS,
+        use_normalization=True,
+        n_steps_input=N_STEPS_INPUT,
+        n_steps_output=N_STEPS_OUTPUT,
+        max_rollout_steps=MAX_ROLLOUT_STEPS,
+        min_dt_stride=1,
+        max_dt_stride=1,
+        local_staging_dir=None,
+    )
+
+    patch_grid_size = SPATIAL_SIZE // PATCH_SIZE  # 8 per dimension
+
+    hyena_3d_mixer_cfg = LazyConfig(QKVSequenceMixer)(
+        hidden_dim=HIDDEN_DIM,
+        mixer_cfg=LazyConfig(Hyena)(
+            global_conv_cfg=LazyConfig(CKConvND)(
+                data_dim=DATA_DIM,
+                hidden_dim=HIDDEN_DIM,
+                fft_padding="zero",
+                kernel_cfg=LazyConfig(SIRENKernelND)(
+                    data_dim=DATA_DIM,
+                    out_dim=HIDDEN_DIM,
+                    mlp_hidden_dim=KERNEL_MLP_HIDDEN_DIM,
+                    num_layers=KERNEL_NUM_LAYERS,
+                    embedding_dim=KERNEL_EMBEDDING_DIM,
+                    omega_0=KERNEL_OMEGA_0,
+                    L_cache=patch_grid_size,
+                    use_bias=True,
+                    hidden_omega_0=KERNEL_HIDDEN_OMEGA_0,
+                ),
+                mask_cfg=LazyConfig(torch.nn.Identity)(),
+                grid_type="single",
+            ),
+            short_conv_cfg=LazyConfig(torch.nn.Conv3d)(
+                in_channels=3 * HIDDEN_DIM,
+                out_channels=3 * HIDDEN_DIM,
+                kernel_size=3,
+                groups=3 * HIDDEN_DIM,
+                padding=1,
+                bias=False,
+            ),
+            gate_nonlinear_cfg=LazyConfig(torch.nn.SiLU)(),
+            gate_nonlinear_2_cfg=LazyConfig(torch.nn.Sigmoid)(),
+            pixelhyena_norm_cfg=LazyConfig(RMSNorm)(dim=HIDDEN_DIM, eps=1e-6),
+            qk_norm_cfg=LazyConfig(L2Norm)(),
+            use_rope=False,
+            output_norm_cfg=LazyConfig(RMSNorm)(dim=HIDDEN_DIM, eps=1e-6),
+        ),
+        qkv_bias=False,
+        out_proj_bias=False,
+        init_method_in=INIT_FN_FACTORY,
+        init_method_out=INIT_FN_FACTORY,
+    )
+
+    # Wrap with ViT5HyenaAdapterND: strips registers, reshapes to 3D grid, applies 3D Hyena, re-prepends
+    adapter_cfg = LazyConfig(ViT5HyenaAdapterND)(
+        inner_mixer_cfg=hyena_3d_mixer_cfg,
+        grid_shape=(patch_grid_size,) * DATA_DIM,
+        num_prefix_tokens=NUM_REGISTERS,
+    )
+
+    block_cfg = LazyConfig(ViT5ResidualBlock)(
+        sequence_mixer_cfg=adapter_cfg,
+        sequence_mixer_norm_cfg=LazyConfig(RMSNorm)(dim=HIDDEN_DIM, eps=1e-6),
+        mlp_cfg=LazyConfig(MLP)(
+            dim=HIDDEN_DIM,
+            activation="gelu",
+            expansion_factor=MLP_RATIO,
+            bias=False,
+            dropout_cfg=LazyConfig(torch.nn.Dropout)(p=DROPOUT_RATE),
+            init_method_in=INIT_FN_FACTORY,
+            init_method_out=INIT_FN_FACTORY,
+        ),
+        mlp_norm_cfg=LazyConfig(RMSNorm)(dim=HIDDEN_DIM, eps=1e-6),
+        hidden_dim=HIDDEN_DIM,
+        layer_scale_init=LAYER_SCALE_INIT,
+        drop_path_rate=DROP_PATH_RATE,
+    )
+
+    config.net = LazyConfig(ViT5GeneralPurposeNet)(
+        in_channels=IN_CHANNELS,
+        out_channels=OUT_CHANNELS,
+        hidden_dim=HIDDEN_DIM,
+        num_blocks=NUM_BLOCKS,
+        data_dim=DATA_DIM,
+        patch_size=PATCH_SIZE,
+        input_size=SPATIAL_SIZE,
+        num_registers=NUM_REGISTERS,
+        in_proj_cfg=LazyConfig(Patchify)(
+            in_features=PLACEHOLDER,
+            out_features=PLACEHOLDER,
+            data_dim=DATA_DIM,
+            patch_size=PATCH_SIZE,
+            stride=PATCH_SIZE,
+        ),
+        out_proj_cfg=LazyConfig(Unpatchify)(
+            in_features=PLACEHOLDER,
+            out_features=PLACEHOLDER,
+            data_dim=DATA_DIM,
+            patch_size=PATCH_SIZE,
+            stride=PATCH_SIZE,
+        ),
+        block_cfg=block_cfg,
+        norm_cfg=LazyConfig(RMSNorm)(dim=HIDDEN_DIM, eps=1e-6),
+        dropout_rate=DROPOUT_RATE,
+        use_cls_token=False,
+        prepend_registers=True,
+    )
+
+    config.lightning_wrapper_class = LazyConfig(WELLRegressionWrapper)(
+        metadata=PLACEHOLDER,
+        n_steps_input=N_STEPS_INPUT,
+        n_steps_output=N_STEPS_OUTPUT,
+        max_rollout_steps=MAX_ROLLOUT_STEPS,
+        metric="MSE",
+    )
+
+    config.optimizer = LazyConfig(torch.optim.AdamW)(
+        params=PLACEHOLDER,
+        lr=LEARNING_RATE,
+        weight_decay=WEIGHT_DECAY,
+    )
+
+    config.train = TrainConfig(
+        batch_size="${dataset.batch_size}",
+        iterations=TRAINING_ITERATIONS,
+        grad_clip=GRAD_CLIP,
+        precision="bf16-mixed",
+    )
+
+    config.scheduler = SchedulerConfig(
+        name="cosine",
+        warmup_iterations_percentage=WARMUP_ITERATIONS_PERCENTAGE,
+        total_iterations="${train.iterations}",
+        mode="min",
+    )
+
+    config.wandb = WandbConfig(
+        entity="implicit-long-convs",
+        project="nvsubquadratic",
+        job_group="MHD_64_vit5_hyena_3d",
+    )
+
+    return config

--- a/examples/well/v1/MHD_64/cfg_vit5_hyena_film_conditioned.py
+++ b/examples/well/v1/MHD_64/cfg_vit5_hyena_film_conditioned.py
@@ -1,0 +1,228 @@
+"""MHD_64 ViT5-style FiLM-conditioned Hyena config."""
+
+import os
+
+import torch
+
+from experiments.datamodules.pde.well import WellDataModule
+from experiments.default_cfg import ExperimentConfig, SchedulerConfig, TrainConfig, WandbConfig
+from experiments.lightning_wrappers.well_lightning_wrapper import WELLRegressionWrapper
+from nvsubquadratic.lazy_config import LazyConfig
+from nvsubquadratic.modules.ckconv_nd import CKConvND
+from nvsubquadratic.modules.film import KernelFiLMGenerator, RegisterPooling
+from nvsubquadratic.modules.hyena_nd import Hyena
+from nvsubquadratic.modules.kernels_nd import SIRENKernelND
+from nvsubquadratic.modules.mlp import MLP
+from nvsubquadratic.modules.patchify import Patchify, Unpatchify
+from nvsubquadratic.modules.rms_norm import RMSNorm
+from nvsubquadratic.modules.sequence_mixer import QKVSequenceMixer
+from nvsubquadratic.modules.vit5_residual_block import ViT5ResidualBlock
+from nvsubquadratic.networks.vit5_general_purpose import ViT5GeneralPurposeNet
+from nvsubquadratic.utils.init import trunc_normal_init_factory
+from nvsubquadratic.utils.qk_norm import L2Norm
+
+
+PLACEHOLDER = None
+
+DATA_DIM = 3
+SPATIAL_SIZE = 64
+WELL_BASE_PATH = os.environ.get("WELL_DATA_PATH", "/gpfs/scratch1/shared/dwessels2/data/the_well/datasets")
+WELL_DATASET_NAME = "MHD_64"
+
+N_STEPS_INPUT = 4
+N_STEPS_OUTPUT = 1
+MAX_ROLLOUT_STEPS = 1
+
+N_FIELDS = 7
+N_CONSTANT_FIELDS = 0
+IN_CHANNELS = N_STEPS_INPUT * N_FIELDS + N_CONSTANT_FIELDS
+OUT_CHANNELS = N_FIELDS
+
+BATCH_SIZE = int(os.environ.get("MHD_VIT5_HYENA_BATCH_SIZE", 8))
+HIDDEN_DIM = int(os.environ.get("MHD_VIT5_HYENA_HIDDEN_DIM", 384))
+NUM_BLOCKS = int(os.environ.get("MHD_VIT5_HYENA_DEPTH", 12))
+NUM_REGISTERS = 14
+DROPOUT_RATE = 0.0
+DROP_PATH_RATE = 0.05
+LAYER_SCALE_INIT = 1e-4
+MLP_RATIO = 4.0
+PATCH_SIZE = int(os.environ.get("MHD_VIT5_HYENA_PATCH_SIZE", 8))
+
+TRAINING_ITERATIONS = 260_000
+WARMUP_ITERATIONS_PERCENTAGE = 0.1
+NUM_WORKERS = 8
+GRAD_CLIP = 1.0
+
+WEIGHT_DECAY = 1e-5
+LEARNING_RATE = 1e-3
+
+KERNEL_MLP_HIDDEN_DIM = 32
+KERNEL_NUM_LAYERS = 3
+KERNEL_EMBEDDING_DIM = 32
+KERNEL_OMEGA_0 = 10.0
+KERNEL_HIDDEN_OMEGA_0 = 1.0
+FILM_HIDDEN_DIM = 64
+
+INIT_FN_FACTORY = trunc_normal_init_factory(std=0.02)
+
+
+def get_config() -> ExperimentConfig:
+    """Return the MHD_64 ViT5-style FiLM-conditioned Hyena config."""
+    config = ExperimentConfig()
+
+    config.debug = False
+    config.compile = True
+    config.compile_mode = "max-autotune-no-cudagraphs"
+    config.compile_compatible_fftconv = True
+
+    config.dataset = LazyConfig(WellDataModule)(
+        well_base_path=WELL_BASE_PATH,
+        well_dataset_name=WELL_DATASET_NAME,
+        batch_size=BATCH_SIZE,
+        num_workers=NUM_WORKERS,
+        use_normalization=True,
+        n_steps_input=N_STEPS_INPUT,
+        n_steps_output=N_STEPS_OUTPUT,
+        max_rollout_steps=MAX_ROLLOUT_STEPS,
+        min_dt_stride=1,
+        max_dt_stride=1,
+        local_staging_dir=None,
+    )
+
+    num_patch_tokens = (SPATIAL_SIZE // PATCH_SIZE) ** DATA_DIM
+
+    film_cfg = LazyConfig(KernelFiLMGenerator)(
+        cond_dim=HIDDEN_DIM,
+        kernel_hidden_dim=KERNEL_MLP_HIDDEN_DIM,
+        num_film_layers=KERNEL_NUM_LAYERS - 1,
+        film_hidden_dim=FILM_HIDDEN_DIM,
+    )
+
+    mixer_cfg = LazyConfig(QKVSequenceMixer)(
+        hidden_dim=HIDDEN_DIM,
+        mixer_cfg=LazyConfig(Hyena)(
+            global_conv_cfg=LazyConfig(CKConvND)(
+                data_dim=1,
+                hidden_dim=HIDDEN_DIM,
+                fft_padding="zero",
+                kernel_cfg=LazyConfig(SIRENKernelND)(
+                    data_dim=1,
+                    out_dim=HIDDEN_DIM,
+                    mlp_hidden_dim=KERNEL_MLP_HIDDEN_DIM,
+                    num_layers=KERNEL_NUM_LAYERS,
+                    embedding_dim=KERNEL_EMBEDDING_DIM,
+                    omega_0=KERNEL_OMEGA_0,
+                    L_cache=num_patch_tokens + NUM_REGISTERS,
+                    use_bias=True,
+                    hidden_omega_0=KERNEL_HIDDEN_OMEGA_0,
+                    film_cfg=film_cfg,
+                ),
+                mask_cfg=LazyConfig(torch.nn.Identity)(),
+                grid_type="single",
+            ),
+            short_conv_cfg=LazyConfig(torch.nn.Conv1d)(
+                in_channels=3 * HIDDEN_DIM,
+                out_channels=3 * HIDDEN_DIM,
+                kernel_size=3,
+                groups=3 * HIDDEN_DIM,
+                padding=1,
+                bias=False,
+            ),
+            gate_nonlinear_cfg=LazyConfig(torch.nn.SiLU)(),
+            gate_nonlinear_2_cfg=LazyConfig(torch.nn.Sigmoid)(),
+            pixelhyena_norm_cfg=LazyConfig(RMSNorm)(dim=HIDDEN_DIM, eps=1e-6),
+            qk_norm_cfg=LazyConfig(L2Norm)(),
+            use_rope=False,
+            output_norm_cfg=LazyConfig(RMSNorm)(dim=HIDDEN_DIM, eps=1e-6),
+        ),
+        qkv_bias=False,
+        out_proj_bias=False,
+        init_method_in=INIT_FN_FACTORY,
+        init_method_out=INIT_FN_FACTORY,
+    )
+
+    block_cfg = LazyConfig(ViT5ResidualBlock)(
+        sequence_mixer_cfg=mixer_cfg,
+        sequence_mixer_norm_cfg=LazyConfig(RMSNorm)(dim=HIDDEN_DIM, eps=1e-6),
+        mlp_cfg=LazyConfig(MLP)(
+            dim=HIDDEN_DIM,
+            activation="gelu",
+            expansion_factor=MLP_RATIO,
+            bias=False,
+            dropout_cfg=LazyConfig(torch.nn.Dropout)(p=DROPOUT_RATE),
+            init_method_in=INIT_FN_FACTORY,
+            init_method_out=INIT_FN_FACTORY,
+        ),
+        mlp_norm_cfg=LazyConfig(RMSNorm)(dim=HIDDEN_DIM, eps=1e-6),
+        hidden_dim=HIDDEN_DIM,
+        layer_scale_init=LAYER_SCALE_INIT,
+        drop_path_rate=DROP_PATH_RATE,
+        register_pooling_cfg=LazyConfig(RegisterPooling)(num_registers=NUM_REGISTERS),
+        num_registers=NUM_REGISTERS,
+    )
+
+    config.net = LazyConfig(ViT5GeneralPurposeNet)(
+        in_channels=IN_CHANNELS,
+        out_channels=OUT_CHANNELS,
+        num_blocks=NUM_BLOCKS,
+        hidden_dim=HIDDEN_DIM,
+        data_dim=DATA_DIM,
+        patch_size=PATCH_SIZE,
+        input_size=SPATIAL_SIZE,
+        num_registers=NUM_REGISTERS,
+        in_proj_cfg=LazyConfig(Patchify)(
+            in_features=PLACEHOLDER,
+            out_features=PLACEHOLDER,
+            data_dim=DATA_DIM,
+            patch_size=PATCH_SIZE,
+            stride=PATCH_SIZE,
+        ),
+        out_proj_cfg=LazyConfig(Unpatchify)(
+            in_features=PLACEHOLDER,
+            out_features=PLACEHOLDER,
+            data_dim=DATA_DIM,
+            patch_size=PATCH_SIZE,
+            stride=PATCH_SIZE,
+        ),
+        block_cfg=block_cfg,
+        norm_cfg=LazyConfig(RMSNorm)(dim=HIDDEN_DIM, eps=1e-6),
+        dropout_rate=DROPOUT_RATE,
+        use_cls_token=False,
+        prepend_registers=True,
+    )
+
+    config.lightning_wrapper_class = LazyConfig(WELLRegressionWrapper)(
+        metadata=PLACEHOLDER,
+        n_steps_input=N_STEPS_INPUT,
+        n_steps_output=N_STEPS_OUTPUT,
+        max_rollout_steps=MAX_ROLLOUT_STEPS,
+        metric="MSE",
+    )
+
+    config.optimizer = LazyConfig(torch.optim.AdamW)(
+        params=PLACEHOLDER,
+        lr=LEARNING_RATE,
+        weight_decay=WEIGHT_DECAY,
+    )
+
+    config.train = TrainConfig(
+        batch_size="${dataset.batch_size}",
+        iterations=TRAINING_ITERATIONS,
+        grad_clip=GRAD_CLIP,
+        precision="bf16-mixed",
+    )
+
+    config.scheduler = SchedulerConfig(
+        name="cosine",
+        warmup_iterations_percentage=WARMUP_ITERATIONS_PERCENTAGE,
+        total_iterations="${train.iterations}",
+        mode="min",
+    )
+
+    config.wandb = WandbConfig(
+        entity="implicit-long-convs",
+        project="nvsubquadratic",
+        job_group="MHD_64_vit5_hyena_film",
+    )
+
+    return config

--- a/examples/well/v1/euler_multi_quadrants_periodicBC/cfg_unet_attention.py
+++ b/examples/well/v1/euler_multi_quadrants_periodicBC/cfg_unet_attention.py
@@ -1,0 +1,68 @@
+"""UNet-Attention variant for euler_multi_quadrants_periodicBC.
+
+Replaces ConvNeXt blocks with transformer blocks (multi-head self-attention
++ FFN).  Uses the same encoder-decoder skip-connection structure and
+hyperparameters as cfg_unet_convnext.py.
+
+WARNING: Full self-attention at 512x512 (262k tokens at the first encoder
+stage) is extremely expensive.  This config is intended for architecture
+comparison (FLOPs/params) and small-resolution testing, not production
+training at full resolution.  For practical training consider reducing
+spatial_resolution or using windowed attention.
+"""
+
+from examples.well.euler_multi_quadrants_periodicBC._base import (
+    DATA_DIM,
+    IN_CHANNELS,
+    OUT_CHANNELS,
+    SPATIAL_RESOLUTION,
+    get_base_config,
+)
+from experiments.default_cfg import ExperimentConfig
+from nvsubquadratic.lazy_config import LazyConfig
+from nvsubquadratic.networks.baselines.unet import AttentionBlock, WellUNet
+
+
+# ─── Model hyperparameters ────────────────────────────────────────────────────
+BATCH_SIZE = 24
+LEARNING_RATE = 5e-3
+WEIGHT_DECAY = 1e-4
+
+INIT_FEATURES = 42
+BLOCKS_PER_STAGE = 2
+STAGES = 4
+BLOCKS_AT_NECK = 1
+NUM_HEADS = 6  # head_dim = init_features / num_heads = 7 at first stage
+MLP_RATIO = 4
+GRADIENT_CHECKPOINTING = False
+
+
+def get_config() -> ExperimentConfig:
+    """Build UNet-Attention experiment config for euler_multi_quadrants_periodicBC."""
+    config = get_base_config(
+        batch_size=BATCH_SIZE,
+        learning_rate=LEARNING_RATE,
+        weight_decay=WEIGHT_DECAY,
+    )
+
+    config.compile = True
+    config.compile_mode = "max-autotune-no-cudagraphs"
+
+    config.net = LazyConfig(WellUNet)(
+        dim_in=IN_CHANNELS,
+        dim_out=OUT_CHANNELS,
+        n_spatial_dims=DATA_DIM,
+        spatial_resolution=SPATIAL_RESOLUTION,
+        stages=STAGES,
+        blocks_per_stage=BLOCKS_PER_STAGE,
+        blocks_at_neck=BLOCKS_AT_NECK,
+        init_features=INIT_FEATURES,
+        block_cfg=LazyConfig(AttentionBlock)(
+            n_spatial_dims=DATA_DIM,
+            num_heads=NUM_HEADS,
+            mlp_ratio=MLP_RATIO,
+        ),
+        gradient_checkpointing=GRADIENT_CHECKPOINTING,
+    )
+
+    return config

--- a/examples/well/v1/euler_multi_quadrants_periodicBC/cfg_unet_hyena.py
+++ b/examples/well/v1/euler_multi_quadrants_periodicBC/cfg_unet_hyena.py
@@ -1,0 +1,73 @@
+"""UNet-Hyena variant for euler_multi_quadrants_periodicBC.
+
+Replaces ConvNeXt blocks with Hyena blocks (gated global convolution via
+CKConvND with SIREN kernels + FFN).  Uses the same encoder-decoder
+skip-connection structure and hyperparameters as cfg_unet_convnext.py.
+
+The Hyena global convolution uses circular FFT padding, which is natural
+for this dataset's periodic boundary conditions.  The SIREN kernel's
+L_cache is automatically set per stage to match the spatial resolution
+after downsampling.
+"""
+
+from examples.well.euler_multi_quadrants_periodicBC._base import (
+    DATA_DIM,
+    IN_CHANNELS,
+    OUT_CHANNELS,
+    SPATIAL_RESOLUTION,
+    get_base_config,
+)
+from experiments.default_cfg import ExperimentConfig
+from nvsubquadratic.lazy_config import LazyConfig
+from nvsubquadratic.networks.baselines.unet import HyenaBlock, WellUNet
+
+
+# ─── Model hyperparameters ────────────────────────────────────────────────────
+BATCH_SIZE = 24
+LEARNING_RATE = 5e-3
+WEIGHT_DECAY = 1e-4
+
+INIT_FEATURES = 42
+BLOCKS_PER_STAGE = 2
+STAGES = 4
+BLOCKS_AT_NECK = 1
+MLP_RATIO = 4
+GRADIENT_CHECKPOINTING = False
+
+# Hyena / SIREN parameters
+OMEGA_0 = 30.0
+SIREN_LAYERS = 3
+SIREN_HIDDEN_DIM = 64
+
+
+def get_config() -> ExperimentConfig:
+    """Build UNet-Hyena experiment config for euler_multi_quadrants_periodicBC."""
+    config = get_base_config(
+        batch_size=BATCH_SIZE,
+        learning_rate=LEARNING_RATE,
+        weight_decay=WEIGHT_DECAY,
+    )
+
+    config.compile = True
+    config.compile_mode = "max-autotune-no-cudagraphs"
+
+    config.net = LazyConfig(WellUNet)(
+        dim_in=IN_CHANNELS,
+        dim_out=OUT_CHANNELS,
+        n_spatial_dims=DATA_DIM,
+        spatial_resolution=SPATIAL_RESOLUTION,
+        stages=STAGES,
+        blocks_per_stage=BLOCKS_PER_STAGE,
+        blocks_at_neck=BLOCKS_AT_NECK,
+        init_features=INIT_FEATURES,
+        block_cfg=LazyConfig(HyenaBlock)(
+            n_spatial_dims=DATA_DIM,
+            mlp_ratio=MLP_RATIO,
+            omega_0=OMEGA_0,
+            siren_layers=SIREN_LAYERS,
+            siren_hidden_dim=SIREN_HIDDEN_DIM,
+        ),
+        gradient_checkpointing=GRADIENT_CHECKPOINTING,
+    )
+
+    return config

--- a/examples/well/v1/euler_multi_quadrants_periodicBC/compare_models.py
+++ b/examples/well/v1/euler_multi_quadrants_periodicBC/compare_models.py
@@ -1,0 +1,161 @@
+#!/usr/bin/env python3
+"""Compare FLOPs and parameters for UNet with ConvNeXt, Attention, and Hyena blocks.
+
+Usage:
+    python examples/well/euler_multi_quadrants_periodicBC/compare_models.py
+"""
+
+from __future__ import annotations
+
+import torch
+from torch.utils.flop_counter import FlopCounterMode
+
+from nvsubquadratic.lazy_config import LazyConfig
+from nvsubquadratic.networks.baselines.unet import (
+    AttentionBlock,
+    ConvNeXtBlock,
+    HyenaBlock,
+    UNet,
+)
+
+
+# ─── Shared constants (from _base.py) ────────────────────────────────────────
+DATA_DIM = 2
+SPATIAL_RESOLUTION = (512, 512)
+IN_CHANNELS = 20
+OUT_CHANNELS = 5
+BATCH_SIZE = 1  # for counting
+
+# ─── Shared UNet hyperparameters ──────────────────────────────────────────────
+INIT_FEATURES = 42
+BLOCKS_PER_STAGE = 2
+STAGES = 4
+BLOCKS_AT_NECK = 1
+
+
+def count_params(model: torch.nn.Module) -> int:
+    """Return total number of learnable parameters."""
+    return sum(p.numel() for p in model.parameters())
+
+
+def count_flops(model: torch.nn.Module, x: torch.Tensor) -> int:
+    """Count FLOPs using PyTorch's built-in FlopCounterMode."""
+    flop_counter = FlopCounterMode(display=False)
+    with flop_counter:
+        model(x)
+    return flop_counter.get_total_flops()
+
+
+def fmt_params(n: int) -> str:
+    """Format parameter count as human-readable string."""
+    if n >= 1e6:
+        return f"{n / 1e6:.2f}M"
+    return f"{n / 1e3:.1f}K"
+
+
+def fmt_flops(n: int) -> str:
+    """Format FLOP count as human-readable string."""
+    if n >= 1e12:
+        return f"{n / 1e12:.2f} TFLOPs"
+    if n >= 1e9:
+        return f"{n / 1e9:.2f} GFLOPs"
+    return f"{n / 1e6:.1f} MFLOPs"
+
+
+# ─── Model configs (block_cfg as LazyConfig) ─────────────────────────────────
+
+MODELS = {
+    "UNet-ConvNeXt": LazyConfig(ConvNeXtBlock)(
+        n_spatial_dims=DATA_DIM,
+    ),
+    "UNet-Attention": LazyConfig(AttentionBlock)(
+        n_spatial_dims=DATA_DIM,
+        num_heads=6,
+        mlp_ratio=4,
+    ),
+    "UNet-Hyena": LazyConfig(HyenaBlock)(
+        n_spatial_dims=DATA_DIM,
+        mlp_ratio=4,
+        omega_0=30.0,
+        siren_layers=3,
+        siren_hidden_dim=64,
+    ),
+}
+
+
+def build_model(block_cfg):
+    """Build a UNet with the given block config and shared hyperparameters."""
+    return UNet(
+        dim_in=IN_CHANNELS,
+        dim_out=OUT_CHANNELS,
+        n_spatial_dims=DATA_DIM,
+        spatial_resolution=SPATIAL_RESOLUTION,
+        stages=STAGES,
+        blocks_per_stage=BLOCKS_PER_STAGE,
+        blocks_at_neck=BLOCKS_AT_NECK,
+        init_features=INIT_FEATURES,
+        block_cfg=block_cfg,
+    )
+
+
+def main():
+    """Build all three UNet variants and print a FLOPs/params comparison table."""
+    print("=" * 76)
+    print("UNet Variant Comparison: euler_multi_quadrants_periodicBC (512x512)")
+    print("=" * 76)
+    print(
+        f"  init_features={INIT_FEATURES}, stages={STAGES}, "
+        f"blocks_per_stage={BLOCKS_PER_STAGE}, blocks_at_neck={BLOCKS_AT_NECK}"
+    )
+    print(f"  input: [{BATCH_SIZE}, {IN_CHANNELS}, {SPATIAL_RESOLUTION[0]}, {SPATIAL_RESOLUTION[1]}]")
+    print()
+
+    results = {}
+    x = torch.randn(BATCH_SIZE, IN_CHANNELS, *SPATIAL_RESOLUTION)
+
+    for name, block_cfg in MODELS.items():
+        print(f"Building {name}...")
+        model = build_model(block_cfg)
+        model.eval()
+        params = count_params(model)
+
+        with torch.no_grad():
+            flops = count_flops(model, x)
+
+        results[name] = {"params": params, "flops": flops}
+        print(f"  Parameters: {fmt_params(params)}")
+        print(f"  FLOPs:      {fmt_flops(flops)}")
+        print()
+
+    # ─── Comparison table ─────────────────────────────────────────────────
+    ref = results["UNet-ConvNeXt"]
+    print("-" * 76)
+    print(f"{'Model':<20} {'Params':>12} {'vs ConvNeXt':>12} {'FLOPs':>16} {'vs ConvNeXt':>12}")
+    print("-" * 76)
+    for name, r in results.items():
+        p_ratio = r["params"] / ref["params"]
+        f_ratio = r["flops"] / ref["flops"] if ref["flops"] > 0 else float("inf")
+        print(
+            f"{name:<20} {fmt_params(r['params']):>12} {p_ratio:>11.2f}x {fmt_flops(r['flops']):>16} {f_ratio:>11.2f}x"
+        )
+    print("-" * 76)
+
+    # ─── Per-stage resolution breakdown ───────────────────────────────────
+    print()
+    print("Per-stage spatial resolutions (encoder blocks operate BEFORE downsampling):")
+    features = INIT_FEATURES
+    for i in range(STAGES):
+        res = SPATIAL_RESOLUTION[0] // (2**i)
+        dim = features * 2**i
+        tokens = res * res
+        print(f"  Encoder stage {i}: {res}x{res} ({tokens:,} tokens), {dim} channels")
+    neck_res = SPATIAL_RESOLUTION[0] // (2**STAGES)
+    print(f"  Neck:           {neck_res}x{neck_res} ({neck_res**2:,} tokens), {features * 2**STAGES} channels")
+
+    print()
+    print("NOTE: Self-attention at 512x512 (262,144 tokens) is O(n^2) and")
+    print("practically infeasible. Hyena's global conv is O(n log n) per stage.")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/well/v1/supernova_explosion_64/cfg_vit5_attention.py
+++ b/examples/well/v1/supernova_explosion_64/cfg_vit5_attention.py
@@ -1,0 +1,181 @@
+# examples/well/supernova_explosion_64/cfg_vit5_attention.py
+
+"""Supernova ViT5-style attention config."""
+
+import os
+
+import torch
+
+from experiments.datamodules.pde.well import WellDataModule
+from experiments.default_cfg import ExperimentConfig, SchedulerConfig, TrainConfig, WandbConfig
+from experiments.lightning_wrappers.well_lightning_wrapper import WELLRegressionWrapper
+from nvsubquadratic.lazy_config import LazyConfig
+from nvsubquadratic.modules.attention import Attention
+from nvsubquadratic.modules.mlp import MLP
+from nvsubquadratic.modules.patchify import Patchify, Unpatchify
+from nvsubquadratic.modules.rms_norm import RMSNorm
+from nvsubquadratic.modules.sequence_mixer import QKVSequenceMixer
+from nvsubquadratic.modules.vit5_residual_block import ViT5ResidualBlock
+from nvsubquadratic.networks.vit5_general_purpose import ViT5GeneralPurposeNet
+from nvsubquadratic.utils.init import trunc_normal_init_factory
+
+
+PLACEHOLDER = None
+
+DATA_DIM = 3
+SPATIAL_SIZE = 64
+WELL_BASE_PATH = os.environ.get("WELL_DATA_PATH", "/gpfs/scratch1/shared/dwessels2/data/the_well/datasets")
+WELL_DATASET_NAME = "supernova_explosion_64"
+
+N_STEPS_INPUT = 4
+N_STEPS_OUTPUT = 1
+MAX_ROLLOUT_STEPS = 1
+
+N_FIELDS = 6
+N_CONSTANT_FIELDS = 0
+IN_CHANNELS = N_STEPS_INPUT * N_FIELDS + N_CONSTANT_FIELDS
+OUT_CHANNELS = N_FIELDS
+
+BATCH_SIZE = int(os.environ.get("SUPERNOVA_VIT5_ATTN_BATCH_SIZE", 16))
+HIDDEN_DIM = int(os.environ.get("SUPERNOVA_VIT5_ATTN_HIDDEN_DIM", 384))
+NUM_BLOCKS = int(os.environ.get("SUPERNOVA_VIT5_ATTN_DEPTH", 12))
+PATCH_SIZE = int(os.environ.get("SUPERNOVA_VIT5_ATTN_PATCH_SIZE", 8))
+NUM_HEADS = int(os.environ.get("SUPERNOVA_VIT5_ATTN_NUM_HEADS", 6))
+NUM_REGISTERS = 14
+DROPOUT_RATE = 0.0
+DROP_PATH_RATE = 0.05
+LAYER_SCALE_INIT = 1e-4
+MLP_RATIO = 4.0
+
+TRAINING_ITERATIONS = 260_000
+WARMUP_ITERATIONS_PERCENTAGE = 0.1
+NUM_WORKERS = 8
+GRAD_CLIP = 1.0
+WEIGHT_DECAY = 1e-5
+LEARNING_RATE = 1e-3
+
+INIT_FN_FACTORY = trunc_normal_init_factory(std=0.02)
+
+
+def get_config() -> ExperimentConfig:
+    """Return the supernova ViT5-style attention config."""
+    config = ExperimentConfig()
+
+    config.debug = False
+    config.compile = True
+    config.compile_mode = "max-autotune-no-cudagraphs"
+
+    config.dataset = LazyConfig(WellDataModule)(
+        well_base_path=WELL_BASE_PATH,
+        well_dataset_name=WELL_DATASET_NAME,
+        batch_size=BATCH_SIZE,
+        num_workers=NUM_WORKERS,
+        use_normalization=True,
+        n_steps_input=N_STEPS_INPUT,
+        n_steps_output=N_STEPS_OUTPUT,
+        max_rollout_steps=MAX_ROLLOUT_STEPS,
+        min_dt_stride=1,
+        max_dt_stride=1,
+        local_staging_dir=None,
+    )
+
+    mixer_cfg = LazyConfig(QKVSequenceMixer)(
+        hidden_dim=HIDDEN_DIM,
+        mixer_cfg=LazyConfig(Attention)(
+            hidden_dim=HIDDEN_DIM,
+            num_heads=NUM_HEADS,
+            apply_qk_norm=True,
+            use_rope=True,
+            is_causal=False,
+            attn_dropout=0.0,
+            rope_base=10000.0,
+        ),
+        qkv_bias=False,
+        out_proj_bias=False,
+        init_method_in=INIT_FN_FACTORY,
+        init_method_out=INIT_FN_FACTORY,
+    )
+
+    block_cfg = LazyConfig(ViT5ResidualBlock)(
+        sequence_mixer_cfg=mixer_cfg,
+        sequence_mixer_norm_cfg=LazyConfig(RMSNorm)(dim=HIDDEN_DIM, eps=1e-6),
+        mlp_cfg=LazyConfig(MLP)(
+            dim=HIDDEN_DIM,
+            activation="gelu",
+            expansion_factor=MLP_RATIO,
+            bias=False,
+            dropout_cfg=LazyConfig(torch.nn.Dropout)(p=DROPOUT_RATE),
+            init_method_in=INIT_FN_FACTORY,
+            init_method_out=INIT_FN_FACTORY,
+        ),
+        mlp_norm_cfg=LazyConfig(RMSNorm)(dim=HIDDEN_DIM, eps=1e-6),
+        hidden_dim=HIDDEN_DIM,
+        layer_scale_init=LAYER_SCALE_INIT,
+        drop_path_rate=DROP_PATH_RATE,
+    )
+
+    config.net = LazyConfig(ViT5GeneralPurposeNet)(
+        in_channels=IN_CHANNELS,
+        out_channels=OUT_CHANNELS,
+        hidden_dim=HIDDEN_DIM,
+        num_blocks=NUM_BLOCKS,
+        data_dim=DATA_DIM,
+        patch_size=PATCH_SIZE,
+        input_size=SPATIAL_SIZE,
+        num_registers=NUM_REGISTERS,
+        in_proj_cfg=LazyConfig(Patchify)(
+            in_features=PLACEHOLDER,
+            out_features=PLACEHOLDER,
+            data_dim=DATA_DIM,
+            patch_size=PATCH_SIZE,
+            stride=PATCH_SIZE,
+        ),
+        out_proj_cfg=LazyConfig(Unpatchify)(
+            in_features=PLACEHOLDER,
+            out_features=PLACEHOLDER,
+            data_dim=DATA_DIM,
+            patch_size=PATCH_SIZE,
+            stride=PATCH_SIZE,
+        ),
+        block_cfg=block_cfg,
+        norm_cfg=LazyConfig(RMSNorm)(dim=HIDDEN_DIM, eps=1e-6),
+        dropout_rate=DROPOUT_RATE,
+        use_cls_token=False,
+        prepend_registers=True,
+    )
+
+    config.lightning_wrapper_class = LazyConfig(WELLRegressionWrapper)(
+        metadata=PLACEHOLDER,
+        n_steps_input=N_STEPS_INPUT,
+        n_steps_output=N_STEPS_OUTPUT,
+        max_rollout_steps=MAX_ROLLOUT_STEPS,
+        metric="MSE",
+    )
+
+    config.optimizer = LazyConfig(torch.optim.AdamW)(
+        params=PLACEHOLDER,
+        lr=LEARNING_RATE,
+        weight_decay=WEIGHT_DECAY,
+    )
+
+    config.train = TrainConfig(
+        batch_size="${dataset.batch_size}",
+        iterations=TRAINING_ITERATIONS,
+        grad_clip=GRAD_CLIP,
+        precision="bf16-mixed",
+    )
+
+    config.scheduler = SchedulerConfig(
+        name="cosine",
+        warmup_iterations_percentage=WARMUP_ITERATIONS_PERCENTAGE,
+        total_iterations="${train.iterations}",
+        mode="min",
+    )
+
+    config.wandb = WandbConfig(
+        entity="implicit-long-convs",
+        project="nvsubquadratic",
+        job_group="supernova_explosion_64_vit5_attention",
+    )
+
+    return config

--- a/examples/well/v1/supernova_explosion_64/cfg_vit5_hyena.py
+++ b/examples/well/v1/supernova_explosion_64/cfg_vit5_hyena.py
@@ -1,0 +1,216 @@
+"""Supernova ViT5-style Hyena config with registers and no FiLM."""
+
+import os
+
+import torch
+
+from experiments.datamodules.pde.well import WellDataModule
+from experiments.default_cfg import ExperimentConfig, SchedulerConfig, TrainConfig, WandbConfig
+from experiments.lightning_wrappers.well_lightning_wrapper import WELLRegressionWrapper
+from nvsubquadratic.lazy_config import LazyConfig
+from nvsubquadratic.modules.ckconv_nd import CKConvND
+from nvsubquadratic.modules.hyena_nd import Hyena
+from nvsubquadratic.modules.kernels_nd import SIRENKernelND
+from nvsubquadratic.modules.mlp import MLP
+from nvsubquadratic.modules.patchify import Patchify, Unpatchify
+from nvsubquadratic.modules.rms_norm import RMSNorm
+from nvsubquadratic.modules.sequence_mixer import QKVSequenceMixer
+from nvsubquadratic.modules.vit5_residual_block import ViT5ResidualBlock
+from nvsubquadratic.networks.vit5_general_purpose import ViT5GeneralPurposeNet
+from nvsubquadratic.utils.init import trunc_normal_init_factory
+from nvsubquadratic.utils.qk_norm import L2Norm
+
+
+PLACEHOLDER = None
+
+DATA_DIM = 3
+SPATIAL_SIZE = 64
+WELL_BASE_PATH = os.environ.get("WELL_DATA_PATH", "/gpfs/scratch1/shared/dwessels2/data/the_well/datasets")
+WELL_DATASET_NAME = "supernova_explosion_64"
+
+N_STEPS_INPUT = 4
+N_STEPS_OUTPUT = 1
+MAX_ROLLOUT_STEPS = 1
+
+N_FIELDS = 6
+N_CONSTANT_FIELDS = 0
+IN_CHANNELS = N_STEPS_INPUT * N_FIELDS + N_CONSTANT_FIELDS
+OUT_CHANNELS = N_FIELDS
+
+BATCH_SIZE = int(os.environ.get("SUPERNOVA_VIT5_HYENA_BATCH_SIZE", 16))
+HIDDEN_DIM = int(os.environ.get("SUPERNOVA_VIT5_HYENA_HIDDEN_DIM", 384))
+NUM_BLOCKS = int(os.environ.get("SUPERNOVA_VIT5_HYENA_DEPTH", 12))
+NUM_REGISTERS = 14
+DROPOUT_RATE = 0.0
+DROP_PATH_RATE = 0.05
+LAYER_SCALE_INIT = 1e-4
+MLP_RATIO = 4.0
+PATCH_SIZE = int(os.environ.get("SUPERNOVA_VIT5_HYENA_PATCH_SIZE", 8))
+
+TRAINING_ITERATIONS = 260_000
+WARMUP_ITERATIONS_PERCENTAGE = 0.1
+NUM_WORKERS = 8
+GRAD_CLIP = 1.0
+
+WEIGHT_DECAY = 1e-5
+LEARNING_RATE = 1e-3
+
+KERNEL_MLP_HIDDEN_DIM = 32
+KERNEL_NUM_LAYERS = 3
+KERNEL_EMBEDDING_DIM = 32
+KERNEL_OMEGA_0 = 10.0
+KERNEL_HIDDEN_OMEGA_0 = 1.0
+
+INIT_FN_FACTORY = trunc_normal_init_factory(std=0.02)
+
+
+def get_config() -> ExperimentConfig:
+    """Return the supernova ViT5-style Hyena config without FiLM."""
+    config = ExperimentConfig()
+
+    config.debug = False
+    config.compile = True
+    config.compile_mode = "max-autotune-no-cudagraphs"
+    config.compile_compatible_fftconv = True
+
+    config.dataset = LazyConfig(WellDataModule)(
+        well_base_path=WELL_BASE_PATH,
+        well_dataset_name=WELL_DATASET_NAME,
+        batch_size=BATCH_SIZE,
+        num_workers=NUM_WORKERS,
+        use_normalization=True,
+        n_steps_input=N_STEPS_INPUT,
+        n_steps_output=N_STEPS_OUTPUT,
+        max_rollout_steps=MAX_ROLLOUT_STEPS,
+        min_dt_stride=1,
+        max_dt_stride=1,
+        local_staging_dir=None,
+    )
+
+    num_patch_tokens = (SPATIAL_SIZE // PATCH_SIZE) ** DATA_DIM
+
+    mixer_cfg = LazyConfig(QKVSequenceMixer)(
+        hidden_dim=HIDDEN_DIM,
+        mixer_cfg=LazyConfig(Hyena)(
+            global_conv_cfg=LazyConfig(CKConvND)(
+                data_dim=1,
+                hidden_dim=HIDDEN_DIM,
+                fft_padding="zero",
+                kernel_cfg=LazyConfig(SIRENKernelND)(
+                    data_dim=1,
+                    out_dim=HIDDEN_DIM,
+                    mlp_hidden_dim=KERNEL_MLP_HIDDEN_DIM,
+                    num_layers=KERNEL_NUM_LAYERS,
+                    embedding_dim=KERNEL_EMBEDDING_DIM,
+                    omega_0=KERNEL_OMEGA_0,
+                    L_cache=num_patch_tokens + NUM_REGISTERS,
+                    use_bias=True,
+                    hidden_omega_0=KERNEL_HIDDEN_OMEGA_0,
+                ),
+                mask_cfg=LazyConfig(torch.nn.Identity)(),
+                grid_type="single",
+            ),
+            short_conv_cfg=LazyConfig(torch.nn.Conv1d)(
+                in_channels=3 * HIDDEN_DIM,
+                out_channels=3 * HIDDEN_DIM,
+                kernel_size=3,
+                groups=3 * HIDDEN_DIM,
+                padding=1,
+                bias=False,
+            ),
+            gate_nonlinear_cfg=LazyConfig(torch.nn.SiLU)(),
+            gate_nonlinear_2_cfg=LazyConfig(torch.nn.Sigmoid)(),
+            pixelhyena_norm_cfg=LazyConfig(RMSNorm)(dim=HIDDEN_DIM, eps=1e-6),
+            qk_norm_cfg=LazyConfig(L2Norm)(),
+            use_rope=False,
+            output_norm_cfg=LazyConfig(RMSNorm)(dim=HIDDEN_DIM, eps=1e-6),
+        ),
+        qkv_bias=False,
+        out_proj_bias=False,
+        init_method_in=INIT_FN_FACTORY,
+        init_method_out=INIT_FN_FACTORY,
+    )
+
+    block_cfg = LazyConfig(ViT5ResidualBlock)(
+        sequence_mixer_cfg=mixer_cfg,
+        sequence_mixer_norm_cfg=LazyConfig(RMSNorm)(dim=HIDDEN_DIM, eps=1e-6),
+        mlp_cfg=LazyConfig(MLP)(
+            dim=HIDDEN_DIM,
+            activation="gelu",
+            expansion_factor=MLP_RATIO,
+            bias=False,
+            dropout_cfg=LazyConfig(torch.nn.Dropout)(p=DROPOUT_RATE),
+            init_method_in=INIT_FN_FACTORY,
+            init_method_out=INIT_FN_FACTORY,
+        ),
+        mlp_norm_cfg=LazyConfig(RMSNorm)(dim=HIDDEN_DIM, eps=1e-6),
+        hidden_dim=HIDDEN_DIM,
+        layer_scale_init=LAYER_SCALE_INIT,
+        drop_path_rate=DROP_PATH_RATE,
+    )
+
+    config.net = LazyConfig(ViT5GeneralPurposeNet)(
+        in_channels=IN_CHANNELS,
+        out_channels=OUT_CHANNELS,
+        hidden_dim=HIDDEN_DIM,
+        num_blocks=NUM_BLOCKS,
+        data_dim=DATA_DIM,
+        patch_size=PATCH_SIZE,
+        input_size=SPATIAL_SIZE,
+        num_registers=NUM_REGISTERS,
+        in_proj_cfg=LazyConfig(Patchify)(
+            in_features=PLACEHOLDER,
+            out_features=PLACEHOLDER,
+            data_dim=DATA_DIM,
+            patch_size=PATCH_SIZE,
+            stride=PATCH_SIZE,
+        ),
+        out_proj_cfg=LazyConfig(Unpatchify)(
+            in_features=PLACEHOLDER,
+            out_features=PLACEHOLDER,
+            data_dim=DATA_DIM,
+            patch_size=PATCH_SIZE,
+            stride=PATCH_SIZE,
+        ),
+        block_cfg=block_cfg,
+        norm_cfg=LazyConfig(RMSNorm)(dim=HIDDEN_DIM, eps=1e-6),
+        dropout_rate=DROPOUT_RATE,
+        use_cls_token=False,
+        prepend_registers=True,
+    )
+
+    config.lightning_wrapper_class = LazyConfig(WELLRegressionWrapper)(
+        metadata=PLACEHOLDER,
+        n_steps_input=N_STEPS_INPUT,
+        n_steps_output=N_STEPS_OUTPUT,
+        max_rollout_steps=MAX_ROLLOUT_STEPS,
+        metric="MSE",
+    )
+
+    config.optimizer = LazyConfig(torch.optim.AdamW)(
+        params=PLACEHOLDER,
+        lr=LEARNING_RATE,
+        weight_decay=WEIGHT_DECAY,
+    )
+
+    config.train = TrainConfig(
+        batch_size="${dataset.batch_size}",
+        iterations=TRAINING_ITERATIONS,
+        grad_clip=GRAD_CLIP,
+        precision="bf16-mixed",
+    )
+
+    config.scheduler = SchedulerConfig(
+        name="cosine",
+        warmup_iterations_percentage=WARMUP_ITERATIONS_PERCENTAGE,
+        total_iterations="${train.iterations}",
+        mode="min",
+    )
+
+    config.wandb = WandbConfig(
+        entity="implicit-long-convs",
+        project="nvsubquadratic",
+        job_group="supernova_explosion_64_vit5_hyena",
+    )
+
+    return config

--- a/examples/well/v1/supernova_explosion_64/cfg_vit5_hyena_3d.py
+++ b/examples/well/v1/supernova_explosion_64/cfg_vit5_hyena_3d.py
@@ -1,0 +1,231 @@
+"""Supernova ViT5-style 3D Hyena config with registers.
+
+Same as cfg_vit5_hyena.py but uses ViT5HyenaAdapterND to reshape the flattened
+token sequence back to a 3D patch grid before applying Hyena. This preserves
+3D spatial locality in the short conv (Conv3d) and SIREN kernel (data_dim=3),
+rather than operating on a flattened 1D sequence.
+"""
+
+import os
+
+import torch
+
+from experiments.datamodules.pde.well import WellDataModule
+from experiments.default_cfg import ExperimentConfig, SchedulerConfig, TrainConfig, WandbConfig
+from experiments.lightning_wrappers.well_lightning_wrapper import WELLRegressionWrapper
+from nvsubquadratic.lazy_config import LazyConfig
+from nvsubquadratic.modules.ckconv_nd import CKConvND
+from nvsubquadratic.modules.hyena_nd import Hyena
+from nvsubquadratic.modules.kernels_nd import SIRENKernelND
+from nvsubquadratic.modules.mlp import MLP
+from nvsubquadratic.modules.patchify import Patchify, Unpatchify
+from nvsubquadratic.modules.rms_norm import RMSNorm
+from nvsubquadratic.modules.sequence_mixer import QKVSequenceMixer
+from nvsubquadratic.modules.vit5_hyena_adapter import ViT5HyenaAdapterND
+from nvsubquadratic.modules.vit5_residual_block import ViT5ResidualBlock
+from nvsubquadratic.networks.vit5_general_purpose import ViT5GeneralPurposeNet
+from nvsubquadratic.utils.init import trunc_normal_init_factory
+from nvsubquadratic.utils.qk_norm import L2Norm
+
+
+PLACEHOLDER = None
+
+DATA_DIM = 3
+SPATIAL_SIZE = 64
+WELL_BASE_PATH = os.environ.get("WELL_DATA_PATH", "/gpfs/scratch1/shared/dwessels2/data/the_well/datasets")
+WELL_DATASET_NAME = "supernova_explosion_64"
+
+N_STEPS_INPUT = 4
+N_STEPS_OUTPUT = 1
+MAX_ROLLOUT_STEPS = 1
+
+N_FIELDS = 6
+N_CONSTANT_FIELDS = 0
+IN_CHANNELS = N_STEPS_INPUT * N_FIELDS + N_CONSTANT_FIELDS
+OUT_CHANNELS = N_FIELDS
+
+BATCH_SIZE = int(os.environ.get("SUPERNOVA_VIT5_HYENA3D_BATCH_SIZE", 2))
+HIDDEN_DIM = int(os.environ.get("SUPERNOVA_VIT5_HYENA3D_HIDDEN_DIM", 384))
+NUM_BLOCKS = int(os.environ.get("SUPERNOVA_VIT5_HYENA3D_DEPTH", 12))
+NUM_REGISTERS = 14
+DROPOUT_RATE = 0.0
+DROP_PATH_RATE = 0.05
+LAYER_SCALE_INIT = 1e-4
+MLP_RATIO = 4.0
+PATCH_SIZE = int(os.environ.get("SUPERNOVA_VIT5_HYENA3D_PATCH_SIZE", 8))
+
+TRAINING_ITERATIONS = 260_000
+WARMUP_ITERATIONS_PERCENTAGE = 0.1
+NUM_WORKERS = 8
+GRAD_CLIP = 1.0
+
+WEIGHT_DECAY = 1e-5
+LEARNING_RATE = 1e-3
+
+KERNEL_MLP_HIDDEN_DIM = 32
+KERNEL_NUM_LAYERS = 3
+KERNEL_EMBEDDING_DIM = 32
+KERNEL_OMEGA_0 = 10.0
+KERNEL_HIDDEN_OMEGA_0 = 1.0
+
+INIT_FN_FACTORY = trunc_normal_init_factory(std=0.02)
+
+
+def get_config() -> ExperimentConfig:
+    """Return the supernova ViT5-style 3D Hyena config."""
+    config = ExperimentConfig()
+
+    config.debug = False
+    config.compile = True
+    config.compile_mode = "max-autotune-no-cudagraphs"
+    config.compile_compatible_fftconv = True
+
+    config.dataset = LazyConfig(WellDataModule)(
+        well_base_path=WELL_BASE_PATH,
+        well_dataset_name=WELL_DATASET_NAME,
+        batch_size=BATCH_SIZE,
+        num_workers=NUM_WORKERS,
+        use_normalization=True,
+        n_steps_input=N_STEPS_INPUT,
+        n_steps_output=N_STEPS_OUTPUT,
+        max_rollout_steps=MAX_ROLLOUT_STEPS,
+        min_dt_stride=1,
+        max_dt_stride=1,
+        local_staging_dir=None,
+    )
+
+    patch_grid_size = SPATIAL_SIZE // PATCH_SIZE  # 8 per dimension (with patch_size=8)
+
+    # 3D Hyena mixer: Conv3d short conv + data_dim=3 SIREN kernel
+    hyena_3d_mixer_cfg = LazyConfig(QKVSequenceMixer)(
+        hidden_dim=HIDDEN_DIM,
+        mixer_cfg=LazyConfig(Hyena)(
+            global_conv_cfg=LazyConfig(CKConvND)(
+                data_dim=DATA_DIM,
+                hidden_dim=HIDDEN_DIM,
+                fft_padding="zero",
+                kernel_cfg=LazyConfig(SIRENKernelND)(
+                    data_dim=DATA_DIM,
+                    out_dim=HIDDEN_DIM,
+                    mlp_hidden_dim=KERNEL_MLP_HIDDEN_DIM,
+                    num_layers=KERNEL_NUM_LAYERS,
+                    embedding_dim=KERNEL_EMBEDDING_DIM,
+                    omega_0=KERNEL_OMEGA_0,
+                    L_cache=patch_grid_size,
+                    use_bias=True,
+                    hidden_omega_0=KERNEL_HIDDEN_OMEGA_0,
+                ),
+                mask_cfg=LazyConfig(torch.nn.Identity)(),
+                grid_type="single",
+            ),
+            short_conv_cfg=LazyConfig(torch.nn.Conv3d)(
+                in_channels=3 * HIDDEN_DIM,
+                out_channels=3 * HIDDEN_DIM,
+                kernel_size=3,
+                groups=3 * HIDDEN_DIM,
+                padding=1,
+                bias=False,
+            ),
+            gate_nonlinear_cfg=LazyConfig(torch.nn.SiLU)(),
+            gate_nonlinear_2_cfg=LazyConfig(torch.nn.Sigmoid)(),
+            pixelhyena_norm_cfg=LazyConfig(RMSNorm)(dim=HIDDEN_DIM, eps=1e-6),
+            qk_norm_cfg=LazyConfig(L2Norm)(),
+            use_rope=False,
+            output_norm_cfg=LazyConfig(RMSNorm)(dim=HIDDEN_DIM, eps=1e-6),
+        ),
+        qkv_bias=False,
+        out_proj_bias=False,
+        init_method_in=INIT_FN_FACTORY,
+        init_method_out=INIT_FN_FACTORY,
+    )
+
+    # Wrap with ViT5HyenaAdapterND: strips registers, reshapes to 3D grid, applies 3D Hyena, re-prepends
+    adapter_cfg = LazyConfig(ViT5HyenaAdapterND)(
+        inner_mixer_cfg=hyena_3d_mixer_cfg,
+        grid_shape=(patch_grid_size,) * DATA_DIM,
+        num_prefix_tokens=NUM_REGISTERS,
+    )
+
+    block_cfg = LazyConfig(ViT5ResidualBlock)(
+        sequence_mixer_cfg=adapter_cfg,
+        sequence_mixer_norm_cfg=LazyConfig(RMSNorm)(dim=HIDDEN_DIM, eps=1e-6),
+        mlp_cfg=LazyConfig(MLP)(
+            dim=HIDDEN_DIM,
+            activation="gelu",
+            expansion_factor=MLP_RATIO,
+            bias=False,
+            dropout_cfg=LazyConfig(torch.nn.Dropout)(p=DROPOUT_RATE),
+            init_method_in=INIT_FN_FACTORY,
+            init_method_out=INIT_FN_FACTORY,
+        ),
+        mlp_norm_cfg=LazyConfig(RMSNorm)(dim=HIDDEN_DIM, eps=1e-6),
+        hidden_dim=HIDDEN_DIM,
+        layer_scale_init=LAYER_SCALE_INIT,
+        drop_path_rate=DROP_PATH_RATE,
+    )
+
+    config.net = LazyConfig(ViT5GeneralPurposeNet)(
+        in_channels=IN_CHANNELS,
+        out_channels=OUT_CHANNELS,
+        hidden_dim=HIDDEN_DIM,
+        num_blocks=NUM_BLOCKS,
+        data_dim=DATA_DIM,
+        patch_size=PATCH_SIZE,
+        input_size=SPATIAL_SIZE,
+        num_registers=NUM_REGISTERS,
+        in_proj_cfg=LazyConfig(Patchify)(
+            in_features=PLACEHOLDER,
+            out_features=PLACEHOLDER,
+            data_dim=DATA_DIM,
+            patch_size=PATCH_SIZE,
+            stride=PATCH_SIZE,
+        ),
+        out_proj_cfg=LazyConfig(Unpatchify)(
+            in_features=PLACEHOLDER,
+            out_features=PLACEHOLDER,
+            data_dim=DATA_DIM,
+            patch_size=PATCH_SIZE,
+            stride=PATCH_SIZE,
+        ),
+        block_cfg=block_cfg,
+        norm_cfg=LazyConfig(RMSNorm)(dim=HIDDEN_DIM, eps=1e-6),
+        dropout_rate=DROPOUT_RATE,
+        use_cls_token=False,
+        prepend_registers=True,
+    )
+
+    config.lightning_wrapper_class = LazyConfig(WELLRegressionWrapper)(
+        metadata=PLACEHOLDER,
+        n_steps_input=N_STEPS_INPUT,
+        n_steps_output=N_STEPS_OUTPUT,
+        max_rollout_steps=MAX_ROLLOUT_STEPS,
+        metric="MSE",
+    )
+
+    config.optimizer = LazyConfig(torch.optim.AdamW)(
+        params=PLACEHOLDER,
+        lr=LEARNING_RATE,
+        weight_decay=WEIGHT_DECAY,
+    )
+
+    config.train = TrainConfig(
+        batch_size="${dataset.batch_size}",
+        iterations=TRAINING_ITERATIONS,
+        grad_clip=GRAD_CLIP,
+        precision="bf16-mixed",
+    )
+
+    config.scheduler = SchedulerConfig(
+        name="cosine",
+        warmup_iterations_percentage=WARMUP_ITERATIONS_PERCENTAGE,
+        total_iterations="${train.iterations}",
+        mode="min",
+    )
+
+    config.wandb = WandbConfig(
+        entity="implicit-long-convs",
+        project="nvsubquadratic",
+        job_group="supernova_explosion_64_vit5_hyena_3d",
+    )
+
+    return config

--- a/examples/well/v1/supernova_explosion_64/cfg_vit5_hyena_film_conditioned.py
+++ b/examples/well/v1/supernova_explosion_64/cfg_vit5_hyena_film_conditioned.py
@@ -1,0 +1,228 @@
+"""Supernova ViT5-style FiLM-conditioned Hyena config."""
+
+import os
+
+import torch
+
+from experiments.datamodules.pde.well import WellDataModule
+from experiments.default_cfg import ExperimentConfig, SchedulerConfig, TrainConfig, WandbConfig
+from experiments.lightning_wrappers.well_lightning_wrapper import WELLRegressionWrapper
+from nvsubquadratic.lazy_config import LazyConfig
+from nvsubquadratic.modules.ckconv_nd import CKConvND
+from nvsubquadratic.modules.film import KernelFiLMGenerator, RegisterPooling
+from nvsubquadratic.modules.hyena_nd import Hyena
+from nvsubquadratic.modules.kernels_nd import SIRENKernelND
+from nvsubquadratic.modules.mlp import MLP
+from nvsubquadratic.modules.patchify import Patchify, Unpatchify
+from nvsubquadratic.modules.rms_norm import RMSNorm
+from nvsubquadratic.modules.sequence_mixer import QKVSequenceMixer
+from nvsubquadratic.modules.vit5_residual_block import ViT5ResidualBlock
+from nvsubquadratic.networks.vit5_general_purpose import ViT5GeneralPurposeNet
+from nvsubquadratic.utils.init import trunc_normal_init_factory
+from nvsubquadratic.utils.qk_norm import L2Norm
+
+
+PLACEHOLDER = None
+
+DATA_DIM = 3
+SPATIAL_SIZE = 64
+WELL_BASE_PATH = os.environ.get("WELL_DATA_PATH", "/gpfs/scratch1/shared/dwessels2/data/the_well/datasets")
+WELL_DATASET_NAME = "supernova_explosion_64"
+
+N_STEPS_INPUT = 4
+N_STEPS_OUTPUT = 1
+MAX_ROLLOUT_STEPS = 1
+
+N_FIELDS = 6
+N_CONSTANT_FIELDS = 0
+IN_CHANNELS = N_STEPS_INPUT * N_FIELDS + N_CONSTANT_FIELDS
+OUT_CHANNELS = N_FIELDS
+
+BATCH_SIZE = int(os.environ.get("SUPERNOVA_VIT5_HYENA_BATCH_SIZE", 2))
+HIDDEN_DIM = int(os.environ.get("SUPERNOVA_VIT5_HYENA_HIDDEN_DIM", 384))
+NUM_BLOCKS = int(os.environ.get("SUPERNOVA_VIT5_HYENA_DEPTH", 12))
+NUM_REGISTERS = 14
+DROPOUT_RATE = 0.0
+DROP_PATH_RATE = 0.05
+LAYER_SCALE_INIT = 1e-4
+MLP_RATIO = 4.0
+PATCH_SIZE = int(os.environ.get("SUPERNOVA_VIT5_HYENA_PATCH_SIZE", 8))
+
+TRAINING_ITERATIONS = 260_000
+WARMUP_ITERATIONS_PERCENTAGE = 0.1
+NUM_WORKERS = 8
+GRAD_CLIP = 1.0
+
+WEIGHT_DECAY = 1e-5
+LEARNING_RATE = 1e-3
+
+KERNEL_MLP_HIDDEN_DIM = 32
+KERNEL_NUM_LAYERS = 3
+KERNEL_EMBEDDING_DIM = 32
+KERNEL_OMEGA_0 = 10.0
+KERNEL_HIDDEN_OMEGA_0 = 1.0
+FILM_HIDDEN_DIM = 64
+
+INIT_FN_FACTORY = trunc_normal_init_factory(std=0.02)
+
+
+def get_config() -> ExperimentConfig:
+    """Return the supernova ViT5-style FiLM-conditioned Hyena config."""
+    config = ExperimentConfig()
+
+    config.debug = False
+    config.compile = True
+    config.compile_mode = "max-autotune-no-cudagraphs"
+    config.compile_compatible_fftconv = True
+
+    config.dataset = LazyConfig(WellDataModule)(
+        well_base_path=WELL_BASE_PATH,
+        well_dataset_name=WELL_DATASET_NAME,
+        batch_size=BATCH_SIZE,
+        num_workers=NUM_WORKERS,
+        use_normalization=True,
+        n_steps_input=N_STEPS_INPUT,
+        n_steps_output=N_STEPS_OUTPUT,
+        max_rollout_steps=MAX_ROLLOUT_STEPS,
+        min_dt_stride=1,
+        max_dt_stride=1,
+        local_staging_dir=None,
+    )
+
+    num_patch_tokens = (SPATIAL_SIZE // PATCH_SIZE) ** DATA_DIM
+
+    film_cfg = LazyConfig(KernelFiLMGenerator)(
+        cond_dim=HIDDEN_DIM,
+        kernel_hidden_dim=KERNEL_MLP_HIDDEN_DIM,
+        num_film_layers=KERNEL_NUM_LAYERS - 1,
+        film_hidden_dim=FILM_HIDDEN_DIM,
+    )
+
+    mixer_cfg = LazyConfig(QKVSequenceMixer)(
+        hidden_dim=HIDDEN_DIM,
+        mixer_cfg=LazyConfig(Hyena)(
+            global_conv_cfg=LazyConfig(CKConvND)(
+                data_dim=1,
+                hidden_dim=HIDDEN_DIM,
+                fft_padding="zero",
+                kernel_cfg=LazyConfig(SIRENKernelND)(
+                    data_dim=1,
+                    out_dim=HIDDEN_DIM,
+                    mlp_hidden_dim=KERNEL_MLP_HIDDEN_DIM,
+                    num_layers=KERNEL_NUM_LAYERS,
+                    embedding_dim=KERNEL_EMBEDDING_DIM,
+                    omega_0=KERNEL_OMEGA_0,
+                    L_cache=num_patch_tokens + NUM_REGISTERS,
+                    use_bias=True,
+                    hidden_omega_0=KERNEL_HIDDEN_OMEGA_0,
+                    film_cfg=film_cfg,
+                ),
+                mask_cfg=LazyConfig(torch.nn.Identity)(),
+                grid_type="single",
+            ),
+            short_conv_cfg=LazyConfig(torch.nn.Conv1d)(
+                in_channels=3 * HIDDEN_DIM,
+                out_channels=3 * HIDDEN_DIM,
+                kernel_size=3,
+                groups=3 * HIDDEN_DIM,
+                padding=1,
+                bias=False,
+            ),
+            gate_nonlinear_cfg=LazyConfig(torch.nn.SiLU)(),
+            gate_nonlinear_2_cfg=LazyConfig(torch.nn.Sigmoid)(),
+            pixelhyena_norm_cfg=LazyConfig(RMSNorm)(dim=HIDDEN_DIM, eps=1e-6),
+            qk_norm_cfg=LazyConfig(L2Norm)(),
+            use_rope=False,
+            output_norm_cfg=LazyConfig(RMSNorm)(dim=HIDDEN_DIM, eps=1e-6),
+        ),
+        qkv_bias=False,
+        out_proj_bias=False,
+        init_method_in=INIT_FN_FACTORY,
+        init_method_out=INIT_FN_FACTORY,
+    )
+
+    block_cfg = LazyConfig(ViT5ResidualBlock)(
+        sequence_mixer_cfg=mixer_cfg,
+        sequence_mixer_norm_cfg=LazyConfig(RMSNorm)(dim=HIDDEN_DIM, eps=1e-6),
+        mlp_cfg=LazyConfig(MLP)(
+            dim=HIDDEN_DIM,
+            activation="gelu",
+            expansion_factor=MLP_RATIO,
+            bias=False,
+            dropout_cfg=LazyConfig(torch.nn.Dropout)(p=DROPOUT_RATE),
+            init_method_in=INIT_FN_FACTORY,
+            init_method_out=INIT_FN_FACTORY,
+        ),
+        mlp_norm_cfg=LazyConfig(RMSNorm)(dim=HIDDEN_DIM, eps=1e-6),
+        hidden_dim=HIDDEN_DIM,
+        layer_scale_init=LAYER_SCALE_INIT,
+        drop_path_rate=DROP_PATH_RATE,
+        register_pooling_cfg=LazyConfig(RegisterPooling)(num_registers=NUM_REGISTERS),
+        num_registers=NUM_REGISTERS,
+    )
+
+    config.net = LazyConfig(ViT5GeneralPurposeNet)(
+        in_channels=IN_CHANNELS,
+        out_channels=OUT_CHANNELS,
+        num_blocks=NUM_BLOCKS,
+        hidden_dim=HIDDEN_DIM,
+        data_dim=DATA_DIM,
+        patch_size=PATCH_SIZE,
+        input_size=SPATIAL_SIZE,
+        num_registers=NUM_REGISTERS,
+        in_proj_cfg=LazyConfig(Patchify)(
+            in_features=PLACEHOLDER,
+            out_features=PLACEHOLDER,
+            data_dim=DATA_DIM,
+            patch_size=PATCH_SIZE,
+            stride=PATCH_SIZE,
+        ),
+        out_proj_cfg=LazyConfig(Unpatchify)(
+            in_features=PLACEHOLDER,
+            out_features=PLACEHOLDER,
+            data_dim=DATA_DIM,
+            patch_size=PATCH_SIZE,
+            stride=PATCH_SIZE,
+        ),
+        block_cfg=block_cfg,
+        norm_cfg=LazyConfig(RMSNorm)(dim=HIDDEN_DIM, eps=1e-6),
+        dropout_rate=DROPOUT_RATE,
+        use_cls_token=False,
+        prepend_registers=True,
+    )
+
+    config.lightning_wrapper_class = LazyConfig(WELLRegressionWrapper)(
+        metadata=PLACEHOLDER,
+        n_steps_input=N_STEPS_INPUT,
+        n_steps_output=N_STEPS_OUTPUT,
+        max_rollout_steps=MAX_ROLLOUT_STEPS,
+        metric="MSE",
+    )
+
+    config.optimizer = LazyConfig(torch.optim.AdamW)(
+        params=PLACEHOLDER,
+        lr=LEARNING_RATE,
+        weight_decay=WEIGHT_DECAY,
+    )
+
+    config.train = TrainConfig(
+        batch_size="${dataset.batch_size}",
+        iterations=TRAINING_ITERATIONS,
+        grad_clip=GRAD_CLIP,
+        precision="bf16-mixed",
+    )
+
+    config.scheduler = SchedulerConfig(
+        name="cosine",
+        warmup_iterations_percentage=WARMUP_ITERATIONS_PERCENTAGE,
+        total_iterations="${train.iterations}",
+        mode="min",
+    )
+
+    config.wandb = WandbConfig(
+        entity="implicit-long-convs",
+        project="nvsubquadratic",
+        job_group="supernova_explosion_64_vit5_hyena_film",
+    )
+
+    return config

--- a/nvsubquadratic/modules/vit5_hyena_adapter.py
+++ b/nvsubquadratic/modules/vit5_hyena_adapter.py
@@ -1,14 +1,17 @@
-"""Adapter to plug 2D sequence mixers (e.g. Hyena) into the ViT5 token-sequence architecture.
+"""Adapters to plug ND sequence mixers (e.g. Hyena) into the ViT5 token-sequence architecture.
 
-The ViT5 architecture processes [B, T, C] sequences. 2D mixers like Hyena expect
-[B, H, W, C] spatial grids. This adapter reshapes the flat token sequence to a 2D
-grid, applies the inner mixer, and reshapes back.
+The ViT5 architecture processes [B, T, C] sequences. ND mixers like Hyena expect
+[B, *spatial_dims, C] spatial grids. These adapters reshape the flat token sequence
+to an ND grid, apply the inner mixer, and reshape back.
 
 All token ordering (CLS position, register placement) is handled upstream by the
-network (e.g. ViT5ClassificationNet with prepend_registers=True), so this adapter
-treats the entire sequence as a flat spatial grid — it does not know or care about
+network (e.g. ViT5ClassificationNet with prepend_registers=True), so these adapters
+treat the entire sequence as a flat spatial grid — they do not know or care about
 which tokens are CLS, registers, or patches.
 """
+
+import math
+from collections.abc import Sequence
 
 import torch
 import torch.nn as nn
@@ -78,3 +81,65 @@ class ViT5HyenaAdapter(nn.Module):
     def extra_repr(self) -> str:
         """Return grid width for repr()."""
         return f"grid_w={self.grid_w}"
+
+
+class ViT5HyenaAdapterND(nn.Module):
+    """Bridges ViT5's [B, T, C] token sequences and Hyena's [B, *spatial_dims, C] spatial interface.
+
+    Generalizes ViT5HyenaAdapter to arbitrary spatial dimensions (1D, 2D, 3D).
+    Optionally strips prefix tokens (e.g. registers) before reshaping, applies the
+    ND mixer to patch tokens only, then re-prepends the prefix unchanged. This is
+    useful when the prefix tokens cannot be cleanly tiled into the ND grid (e.g. 14
+    registers with an 8x8x8 3D patch grid).
+
+    Args:
+        inner_mixer_cfg: LazyConfig for the ND sequence mixer (e.g. QKVSequenceMixer wrapping Hyena).
+        grid_shape: Spatial grid shape as a tuple, e.g. (D, H, W) for 3D or (H, W) for 2D.
+            The product must equal the number of patch tokens (T - num_prefix_tokens).
+        num_prefix_tokens: Number of tokens at the start of the sequence to exclude
+            from the spatial reshape (e.g. CLS + registers). These are re-prepended
+            after the mixer. Default: 0 (all tokens are spatial).
+    """
+
+    def __init__(
+        self,
+        inner_mixer_cfg: LazyConfig,
+        grid_shape: Sequence[int],
+        num_prefix_tokens: int = 0,
+    ):
+        """Store grid shape and instantiate the inner ND mixer."""
+        super().__init__()
+        self.inner_mixer = instantiate(inner_mixer_cfg)
+        self.grid_shape = tuple(grid_shape)
+        self.num_prefix_tokens = num_prefix_tokens
+
+    def forward(self, x: torch.Tensor, **mixer_kwargs) -> torch.Tensor:
+        """Forward pass.
+
+        Args:
+            x: [B, T, C] token sequence.
+            **mixer_kwargs: Forwarded to the inner mixer (e.g. ``conditioning`` for FiLM).
+
+        Returns:
+            [B, T, C] with all tokens mixed via the ND inner mixer.
+            Prefix tokens are expected to be zero-padded upstream so that they cleanly
+            fit into one or more planes along the first spatial dimension.
+        """
+        B, T, C = x.shape
+
+        if len(self.grid_shape) > 1:
+            slice_size = math.prod(self.grid_shape[1:])
+            # The first dimension dynamically expands to accommodate prefix tokens padding upstream
+            first_dim = T // slice_size
+            x = x.reshape(B, first_dim, *self.grid_shape[1:], C)
+        else:
+            x = x.reshape(B, T, C)
+
+        x = self.inner_mixer(x, **mixer_kwargs)
+        x = x.reshape(B, -1, C)
+
+        return x
+
+    def extra_repr(self) -> str:
+        """Return grid shape and prefix info for repr()."""
+        return f"grid_shape={self.grid_shape}, num_prefix_tokens={self.num_prefix_tokens}"

--- a/nvsubquadratic/networks/baselines/unet.py
+++ b/nvsubquadratic/networks/baselines/unet.py
@@ -1,0 +1,486 @@
+"""Unified UNet with pluggable blocks via LazyConfig.
+
+A single encoder-decoder UNet backbone where the per-stage block is
+specified as a ``block_cfg`` LazyConfig — following the same pattern as
+:class:`ResidualNetwork` / :class:`ResidualBlock`.
+
+The UNet fills in ``dim`` and ``spatial_res`` per stage when instantiating
+the block config, so the config only needs to specify block-specific
+parameters (e.g. ``num_heads`` for attention, ``omega_0`` for Hyena).
+
+Built-in block types (importable from this module):
+    - :class:`ConvNeXtBlock` — depthwise-conv + channel MLP (Liu et al., 2022).
+    - :class:`AttentionBlock` — multi-head self-attention + FFN.
+    - :class:`HyenaBlock` — gated global convolution via CKConvND/SIREN + FFN.
+"""
+
+from __future__ import annotations
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+from einops import rearrange
+from timm.layers import DropPath
+from torch.utils.checkpoint import checkpoint
+
+from nvsubquadratic.lazy_config import LazyConfig, instantiate
+from nvsubquadratic.modules.attention import Attention
+from nvsubquadratic.modules.ckconv_nd import CKConvND
+from nvsubquadratic.modules.hyena_nd import Hyena
+from nvsubquadratic.modules.kernels_nd import SIRENKernelND
+from nvsubquadratic.modules.rms_norm import RMSNorm
+from nvsubquadratic.utils.qk_norm import L2Norm
+
+
+# ─── Shared helpers ──────────────────────────────────────────────────────────
+
+conv_modules = {1: nn.Conv1d, 2: nn.Conv2d, 3: nn.Conv3d}
+conv_transpose_modules = {
+    1: nn.ConvTranspose1d,
+    2: nn.ConvTranspose2d,
+    3: nn.ConvTranspose3d,
+}
+
+_TO_CHANNELS_LAST = {
+    2: "N C H W -> N H W C",
+    3: "N C D H W -> N D H W C",
+}
+_TO_CHANNELS_FIRST = {
+    2: "N H W C -> N C H W",
+    3: "N D H W C -> N C D H W",
+}
+
+
+class _LayerNorm(nn.Module):
+    """LayerNorm supporting channels_last and channels_first data formats."""
+
+    def __init__(self, normalized_shape, n_spatial_dims, eps=1e-6, data_format="channels_last"):
+        super().__init__()
+        if data_format == "channels_last":
+            padded_shape = (normalized_shape,)
+        else:
+            padded_shape = (normalized_shape,) + (1,) * n_spatial_dims
+        self.weight = nn.Parameter(torch.ones(padded_shape))
+        if data_format == "channels_last":
+            self.bias = nn.Parameter(torch.zeros(padded_shape))
+        self.n_spatial_dims = n_spatial_dims
+        self.eps = eps
+        self.data_format = data_format
+        self.normalized_shape = (normalized_shape,)
+
+    def forward(self, x):
+        if self.data_format == "channels_last":
+            return F.layer_norm(x, self.normalized_shape, self.weight, self.bias, self.eps)
+        else:
+            return F.normalize(x, p=2, dim=1, eps=self.eps) * self.weight
+
+
+class _Upsample(nn.Module):
+    def __init__(self, dim_in, dim_out, n_spatial_dims=2):
+        super().__init__()
+        self.block = nn.Sequential(
+            _LayerNorm(dim_in, n_spatial_dims, eps=1e-6, data_format="channels_first"),
+            conv_transpose_modules[n_spatial_dims](dim_in, dim_out, kernel_size=2, stride=2),
+        )
+
+    def forward(self, x):
+        return self.block(x)
+
+
+class _Downsample(nn.Module):
+    def __init__(self, dim_in, dim_out, n_spatial_dims=2):
+        super().__init__()
+        self.block = nn.Sequential(
+            _LayerNorm(dim_in, n_spatial_dims, eps=1e-6, data_format="channels_first"),
+            conv_modules[n_spatial_dims](dim_in, dim_out, kernel_size=2, stride=2),
+        )
+
+    def forward(self, x):
+        return self.block(x)
+
+
+# ─── Block implementations ──────────────────────────────────────────────────
+#
+# All blocks share a uniform constructor interface:
+#   (dim, n_spatial_dims, spatial_res=None, drop_path=0.0, ...)
+# so they are interchangeable inside the UNet via LazyConfig.
+# The UNet fills in ``dim`` and ``spatial_res`` per stage.
+
+
+class ConvNeXtBlock(nn.Module):
+    """ConvNeXt block: DwConv 7x7 -> LN -> Linear(4x) -> GELU -> Linear -> residual."""
+
+    def __init__(self, dim, n_spatial_dims, spatial_res=None, drop_path=0.0, layer_scale_init_value=1e-6):
+        """Initialize ConvNeXtBlock with depthwise conv, layer norm, and pointwise MLP."""
+        super().__init__()
+        self.n_spatial_dims = n_spatial_dims
+        self.dwconv = conv_modules[n_spatial_dims](dim, dim, kernel_size=7, padding=3, groups=dim)
+        self.norm = _LayerNorm(dim, n_spatial_dims, eps=1e-6)
+        self.pwconv1 = nn.Linear(dim, 4 * dim)
+        self.act = nn.GELU()
+        self.pwconv2 = nn.Linear(4 * dim, dim)
+        self.gamma = (
+            nn.Parameter(layer_scale_init_value * torch.ones((dim)), requires_grad=True)
+            if layer_scale_init_value > 0
+            else None
+        )
+        self.drop_path = DropPath(drop_path) if drop_path > 0.0 else nn.Identity()
+
+    def forward(self, x):
+        """Apply ConvNeXt block: dwconv -> norm -> MLP -> residual."""
+        residual = x
+        x = self.dwconv(x)
+        x = rearrange(x, _TO_CHANNELS_LAST[self.n_spatial_dims])
+        x = self.norm(x)
+        x = self.pwconv1(x)
+        x = self.act(x)
+        x = self.pwconv2(x)
+        if self.gamma is not None:
+            x = self.gamma * x
+        x = rearrange(x, _TO_CHANNELS_FIRST[self.n_spatial_dims])
+        x = residual + self.drop_path(x)
+        return x
+
+
+class AttentionBlock(nn.Module):
+    """Transformer block: LN -> MHSA -> residual -> LN -> FFN -> residual.
+
+    Operates channels-first externally (NCHW) but converts to channels-last
+    internally for attention and FFN.
+    """
+
+    def __init__(self, dim, n_spatial_dims, spatial_res=None, drop_path=0.0, num_heads=6, mlp_ratio=4):
+        """Initialize AttentionBlock with MHSA, output projection, and FFN."""
+        super().__init__()
+        self.n_spatial_dims = n_spatial_dims
+        self.norm1 = nn.LayerNorm(dim)
+        self.qkv = nn.Linear(dim, 3 * dim, bias=False)
+        self.attn = Attention(
+            hidden_dim=dim,
+            num_heads=num_heads,
+            apply_qk_norm=True,
+            use_rope=False,
+            is_causal=False,
+        )
+        self.out_proj = nn.Linear(dim, dim, bias=False)
+        self.norm2 = nn.LayerNorm(dim)
+        self.pwconv1 = nn.Linear(dim, mlp_ratio * dim)
+        self.act = nn.GELU()
+        self.pwconv2 = nn.Linear(mlp_ratio * dim, dim)
+        self.drop_path = DropPath(drop_path) if drop_path > 0.0 else nn.Identity()
+
+    def forward(self, x):
+        """Apply attention block: MHSA -> residual -> FFN -> residual."""
+        x = rearrange(x, _TO_CHANNELS_LAST[self.n_spatial_dims])
+
+        # Self-attention
+        residual = x
+        x = self.norm1(x)
+        qkv = self.qkv(x)
+        q, k, v = qkv.chunk(3, dim=-1)
+        x = self.attn(q, k, v)
+        x = self.out_proj(x)
+        x = residual + self.drop_path(x)
+
+        # FFN
+        residual = x
+        x = self.norm2(x)
+        x = self.pwconv1(x)
+        x = self.act(x)
+        x = self.pwconv2(x)
+        x = residual + self.drop_path(x)
+
+        x = rearrange(x, _TO_CHANNELS_FIRST[self.n_spatial_dims])
+        return x
+
+
+def _build_hyena(dim, n_spatial_dims, spatial_res, omega_0, siren_layers, siren_hidden_dim):
+    """Create a Hyena module configured for the given channel width and spatial resolution."""
+    global_conv = CKConvND(
+        data_dim=n_spatial_dims,
+        hidden_dim=dim,
+        fft_padding="circular",
+        use_fp16_fft=False,
+        kernel_cfg=SIRENKernelND(
+            data_dim=n_spatial_dims,
+            out_dim=dim,
+            mlp_hidden_dim=siren_hidden_dim,
+            num_layers=siren_layers,
+            embedding_dim=siren_hidden_dim,
+            omega_0=omega_0,
+            L_cache=spatial_res,
+            use_bias=True,
+            hidden_omega_0=1.0,
+        ),
+        mask_cfg=LazyConfig(nn.Identity)(),
+        grid_type="single",
+    )
+    short_conv = conv_modules[n_spatial_dims](
+        in_channels=3 * dim,
+        out_channels=3 * dim,
+        kernel_size=3,
+        groups=3 * dim,
+        padding=1,
+        bias=False,
+    )
+    return Hyena(
+        global_conv_cfg=global_conv,
+        short_conv_cfg=short_conv,
+        gate_nonlinear_cfg=nn.SiLU(),
+        gate_nonlinear_2_cfg=nn.Sigmoid(),
+        pixelhyena_norm_cfg=RMSNorm(dim=dim),
+        output_norm_cfg=RMSNorm(dim=dim),
+        qk_norm_cfg=L2Norm(),
+        use_rope=False,
+    )
+
+
+class HyenaBlock(nn.Module):
+    """Hyena block: LN -> QKV -> Hyena gated global conv -> residual -> LN -> FFN -> residual.
+
+    Operates channels-first externally (NCHW) but converts to channels-last
+    internally for the Hyena mixer and FFN.  ``spatial_res`` is **required** to
+    set the SIREN kernel's L_cache correctly for each UNet stage.
+    """
+
+    def __init__(
+        self,
+        dim,
+        n_spatial_dims,
+        spatial_res=None,
+        drop_path=0.0,
+        mlp_ratio=4,
+        omega_0=30.0,
+        siren_layers=3,
+        siren_hidden_dim=64,
+    ):
+        """Initialize HyenaBlock with gated global conv, output projection, and FFN."""
+        super().__init__()
+        assert spatial_res is not None, "HyenaBlock requires spatial_res for the SIREN kernel"
+        self.n_spatial_dims = n_spatial_dims
+        self.norm1 = nn.LayerNorm(dim)
+        self.qkv = nn.Linear(dim, 3 * dim, bias=False)
+        self.hyena = _build_hyena(dim, n_spatial_dims, spatial_res, omega_0, siren_layers, siren_hidden_dim)
+        self.out_proj = nn.Linear(dim, dim, bias=False)
+        self.norm2 = nn.LayerNorm(dim)
+        self.pwconv1 = nn.Linear(dim, mlp_ratio * dim)
+        self.act = nn.GELU()
+        self.pwconv2 = nn.Linear(mlp_ratio * dim, dim)
+        self.drop_path = DropPath(drop_path) if drop_path > 0.0 else nn.Identity()
+
+    def forward(self, x):
+        """Apply Hyena block: gated global conv -> residual -> FFN -> residual."""
+        x = rearrange(x, _TO_CHANNELS_LAST[self.n_spatial_dims])
+
+        # Hyena mixer
+        residual = x
+        x = self.norm1(x)
+        qkv = self.qkv(x)
+        q, k, v = qkv.chunk(3, dim=-1)
+        x = self.hyena(q, k, v)
+        x = self.out_proj(x)
+        x = residual + self.drop_path(x)
+
+        # FFN
+        residual = x
+        x = self.norm2(x)
+        x = self.pwconv1(x)
+        x = self.act(x)
+        x = self.pwconv2(x)
+        x = residual + self.drop_path(x)
+
+        x = rearrange(x, _TO_CHANNELS_FIRST[self.n_spatial_dims])
+        return x
+
+
+# ─── Unified Stage & UNet ───────────────────────────────────────────────────
+
+
+class _Stage(nn.Module):
+    """UNet stage: sequence of blocks + optional resampling."""
+
+    def __init__(
+        self,
+        dim_in,
+        dim_out,
+        n_spatial_dims,
+        spatial_res,
+        block_cfg,
+        depth=1,
+        drop_path=0.0,
+        mode="down",
+        skip_project=False,
+    ):
+        super().__init__()
+
+        if skip_project:
+            self.skip_proj = conv_modules[n_spatial_dims](2 * dim_in, dim_in, 1)
+        else:
+            self.skip_proj = nn.Identity()
+        if mode == "down":
+            self.resample = _Downsample(dim_in, dim_out, n_spatial_dims)
+        elif mode == "up":
+            self.resample = _Upsample(dim_in, dim_out, n_spatial_dims)
+        else:
+            self.resample = nn.Identity()
+
+        self.blocks = nn.ModuleList(
+            [instantiate(block_cfg, dim=dim_in, spatial_res=spatial_res) for _ in range(depth)]
+        )
+
+    def forward(self, x):
+        x = self.skip_proj(x)
+        for block in self.blocks:
+            x = block(x)
+        x = self.resample(x)
+        return x
+
+
+class UNet(nn.Module):
+    """Unified UNet with pluggable blocks — channels-first (NCHW / NCDHW) interface.
+
+    Follows the same LazyConfig pattern as :class:`ResidualNetwork`: the caller
+    provides a ``block_cfg`` LazyConfig and the UNet fills in ``dim`` and
+    ``spatial_res`` per stage when instantiating blocks.
+
+    Args:
+        dim_in: Number of input channels.
+        dim_out: Number of output channels.
+        n_spatial_dims: 2 for images, 3 for volumes.
+        spatial_resolution: Tuple of spatial sizes (used to compute per-stage
+            resolutions for resolution-aware blocks like Hyena).
+        stages: Number of encoder/decoder stages (default 4).
+        blocks_per_stage: Blocks per stage (default 1).
+        blocks_at_neck: Blocks at bottleneck (default 1).
+        init_features: Feature map width at the first stage (default 32).
+        block_cfg: LazyConfig targeting a block class (e.g. ``ConvNeXtBlock``,
+            ``AttentionBlock``, ``HyenaBlock``).  The UNet fills in ``dim`` and
+            ``spatial_res`` per stage; the config only needs block-specific
+            params (e.g. ``num_heads``, ``omega_0``).
+        gradient_checkpointing: Use activation checkpointing to save memory.
+    """
+
+    def __init__(
+        self,
+        dim_in: int,
+        dim_out: int,
+        n_spatial_dims: int,
+        spatial_resolution: tuple[int, ...] | None = None,
+        stages: int = 4,
+        blocks_per_stage: int = 1,
+        blocks_at_neck: int = 1,
+        init_features: int = 32,
+        block_cfg=None,
+        gradient_checkpointing: bool = False,
+    ):
+        """Build encoder-decoder UNet with the given block config and depth/width."""
+        super().__init__()
+        self.n_spatial_dims = n_spatial_dims
+        features = init_features
+        self.gradient_checkpointing = gradient_checkpointing
+
+        encoder_dims = [features * 2**i for i in range(stages + 1)]
+        decoder_dims = [features * 2**i for i in range(stages, -1, -1)]
+
+        # Per-stage spatial resolutions (assumes isotropic and halves each stage)
+        base_res = spatial_resolution[0] if spatial_resolution else 0
+        stage_resolutions = [base_res // (2**i) for i in range(stages)]
+        neck_resolution = base_res // (2**stages) if base_res else 0
+
+        encoder = []
+        decoder = []
+        self.in_proj = conv_modules[n_spatial_dims](dim_in, features, kernel_size=3, padding=1)
+        self.out_proj = conv_modules[n_spatial_dims](features, dim_out, kernel_size=3, padding=1)
+        for i in range(stages):
+            encoder.append(
+                _Stage(
+                    encoder_dims[i],
+                    encoder_dims[i + 1],
+                    n_spatial_dims,
+                    spatial_res=stage_resolutions[i],
+                    block_cfg=block_cfg,
+                    depth=blocks_per_stage,
+                    mode="down",
+                )
+            )
+            dec_res = neck_resolution * (2**i) if i > 0 else neck_resolution
+            decoder.append(
+                _Stage(
+                    decoder_dims[i],
+                    decoder_dims[i + 1],
+                    n_spatial_dims,
+                    spatial_res=dec_res,
+                    block_cfg=block_cfg,
+                    depth=blocks_per_stage,
+                    mode="up",
+                    skip_project=i != 0,
+                )
+            )
+        self.encoder = nn.ModuleList(encoder)
+        self.neck = _Stage(
+            encoder_dims[-1],
+            encoder_dims[-1],
+            n_spatial_dims,
+            spatial_res=neck_resolution,
+            block_cfg=block_cfg,
+            depth=blocks_at_neck,
+            mode="neck",
+        )
+        self.decoder = nn.ModuleList(decoder)
+
+    def _optional_checkpointing(self, layer, *inputs, **kwargs):
+        if self.gradient_checkpointing:
+            return checkpoint(layer, *inputs, use_reentrant=False, **kwargs)
+        else:
+            return layer(*inputs, **kwargs)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        """Encode with skip connections, process at neck, decode with skip fusion."""
+        x = self.in_proj(x)
+        skips = []
+        for enc in self.encoder:
+            skips.append(x)
+            x = self._optional_checkpointing(enc, x)
+        x = self.neck(x)
+        for j, dec in enumerate(self.decoder):
+            if j > 0:
+                x = torch.cat([x, skips[-j]], dim=1)
+            x = dec(x)
+        x = self.out_proj(x)
+        return x
+
+
+# ─── Channels-last dict wrapper for the nvSubquadratic training infra ────────
+
+_CHANNELS_LAST_TO_FIRST = {
+    2: "B H W C -> B C H W",
+    3: "B D H W C -> B C D H W",
+}
+_CHANNELS_FIRST_TO_LAST = {
+    2: "B C H W -> B H W C",
+    3: "B C D H W -> B D H W C",
+}
+
+
+class WellUNet(nn.Module):
+    """Unified UNet with the dict-based channels-last interface expected by WELLRegressionWrapper.
+
+    Input:  ``{"input": [B, *spatial, C_in], "condition": None}``
+    Output: ``{"logits": [B, *spatial, C_out]}``
+
+    Constructor args are forwarded to :class:`UNet`.
+    """
+
+    def __init__(self, **kwargs):
+        """Initialize by forwarding all kwargs to :class:`UNet`."""
+        super().__init__()
+        self.net = UNet(**kwargs)
+        self._n_spatial_dims = self.net.n_spatial_dims
+
+    def forward(self, input_and_condition: dict[str, torch.Tensor]) -> dict[str, torch.Tensor]:
+        """Transpose to channels-first, run UNet, transpose back."""
+        x = input_and_condition["input"]
+        x = rearrange(x, _CHANNELS_LAST_TO_FIRST[self._n_spatial_dims])
+        y = self.net(x)
+        y = rearrange(y, _CHANNELS_FIRST_TO_LAST[self._n_spatial_dims])
+        return {"logits": y}

--- a/nvsubquadratic/networks/vit5_general_purpose.py
+++ b/nvsubquadratic/networks/vit5_general_purpose.py
@@ -1,0 +1,236 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""General-purpose ViT5-style network for dense ND prediction.
+
+This module is the ViT5 analogue of the repository's general-purpose dense
+network wrapper: it accepts channels-last dense ND inputs, patchifies them to a
+token sequence, applies ViT5-style residual blocks, then unpatchifies back to a
+dense channels-last output.
+
+TODO: add ``target_size`` support for parity with
+``nvsubquadratic.networks.general_purpose_resnet.ResidualNetwork``.
+
+TODO: add ``condition_in_proj_cfg`` support so external conditioning can be
+projected at the network level, matching the general-purpose ResNet wrapper.
+"""
+
+import math
+from collections.abc import Sequence
+
+import torch
+import torch.nn as nn
+from einops import rearrange
+
+from nvsubquadratic.lazy_config import LazyConfig, instantiate
+
+
+class ViT5GeneralPurposeNet(nn.Module):
+    """ViT5-style general-purpose dense network with learnable register tokens.
+
+    The model patchifies an ND input into a patch grid, flattens the patches to
+    tokens, prepends auxiliary tokens, applies ViT5-style residual blocks, then
+    reshapes patch tokens back to the patch grid and unpatchifies to dense
+    outputs.
+
+    TODO: add ``target_size`` support for parity with the general-purpose ResNet.
+
+    TODO: add ``condition_in_proj_cfg`` support for parity with the
+    general-purpose ResNet.
+    """
+
+    def __init__(
+        self,
+        in_channels: int,
+        out_channels: int,
+        hidden_dim: int,
+        num_blocks: int,
+        data_dim: int,
+        patch_size: int | Sequence[int],
+        input_size: int | Sequence[int],
+        num_registers: int,
+        in_proj_cfg: LazyConfig,
+        out_proj_cfg: LazyConfig,
+        block_cfg: LazyConfig,
+        norm_cfg: LazyConfig,
+        dropout_rate: float = 0.0,
+        use_cls_token: bool = False,
+        prepend_registers: bool = True,
+    ):
+        """Initialize the ViT5 general-purpose dense network.
+
+        Args:
+            in_channels: Number of input channels.
+            out_channels: Number of output channels.
+            hidden_dim: Transformer hidden dimension (D).
+            num_blocks: Number of Transformer blocks.
+            data_dim: Dimensionality of the spatial data (e.g. 1, 2, 3).
+            patch_size: Spatial shape of the patch (e.g. `P` for `PxP` patches in 2D). Can be a scalar or a tuple.
+            input_size: Spatial shape of the dense input (e.g. `H` for `H` width/height). Can be a scalar or a tuple.
+            num_registers: Number of learnable register tokens to use.
+            in_proj_cfg: LazyConfig for the linear mapping applied to patchified dense inputs to reach hidden_dim.
+            out_proj_cfg: LazyConfig for the linear mapping applied to the unpatchified grid to reach out_channels.
+            block_cfg: LazyConfig to instantiate each Transformer block.
+            norm_cfg: LazyConfig for the output normalization layer applied before the out_proj.
+            dropout_rate: Dropout rate applied right before the output projection. Let zero to disable.
+            use_cls_token: If True, prepends a learnable [CLS] token to the sequence.
+            prepend_registers: If True, registers will be placed at the beginning of the sequence
+                (just after the CLS token if present). If False, registers are appended to the end.
+                Note that prepended registers are automatically zero-padded to form a clean slice along
+                spatial dimensions (vital for spatial multi-dimensional mixers like Hyena).
+        """
+        super().__init__()
+        self.hidden_dim = hidden_dim
+        self.out_channels = out_channels
+        self.data_dim = data_dim
+        self.num_blocks = num_blocks
+        self.num_registers = num_registers
+        self.use_cls_token = use_cls_token
+        self.prepend_registers = prepend_registers
+
+        self.input_size = self._normalize_nd_value(input_size, data_dim, "input_size")
+        self.patch_size = self._normalize_nd_value(patch_size, data_dim, "patch_size")
+        self.patch_grid_shape = tuple(size // patch for size, patch in zip(self.input_size, self.patch_size))
+        self.num_patches = math.prod(self.patch_grid_shape)
+
+        self.in_proj = instantiate(in_proj_cfg, in_features=in_channels, out_features=hidden_dim)
+        self.out_proj = instantiate(out_proj_cfg, in_features=hidden_dim, out_features=out_channels)
+
+        if use_cls_token:
+            self.cls_token = nn.Parameter(torch.zeros(1, 1, hidden_dim))
+            self.cls_token._no_weight_decay = True
+        else:
+            self.cls_token = None
+
+        self.pos_embed = nn.Parameter(torch.zeros(1, self.num_patches, hidden_dim))
+        self.pos_embed._no_weight_decay = True
+
+        if num_registers > 0:
+            self.reg_token = nn.Parameter(torch.zeros(1, num_registers, hidden_dim))
+            self.reg_token._no_weight_decay = True
+        else:
+            self.reg_token = None
+
+        if len(self.patch_grid_shape) > 1:
+            self._register_plane_size = math.prod(self.patch_grid_shape[1:])
+        else:
+            self._register_plane_size = None
+
+        # Calculate prefix (CLS + registers) size
+        self._prefix_len = 0
+        if self.use_cls_token:
+            self._prefix_len += 1
+        if self.num_registers > 0 and self.prepend_registers:
+            self._prefix_len += self.num_registers
+
+        # Zero-padding buffer for dense ND models: fills the prefix space to gracefully reshape
+        # as a unified multi-dimensional block internally by maintaining clean slice geometries.
+        if self._prefix_len > 0 and self._register_plane_size is not None:
+            assert self._prefix_len <= self._register_plane_size, (
+                f"prefix_len ({self._prefix_len}) > slice size ({self._register_plane_size}); "
+                "prefix tokens must fit in a single slice along spatial dimensions"
+            )
+            pad_size = self._register_plane_size - self._prefix_len
+            if pad_size > 0:
+                self.register_buffer("reg_zero_pad", torch.zeros(1, pad_size, hidden_dim), persistent=False)
+            else:
+                self.reg_zero_pad = None
+            self._padded_prefix_len = self._register_plane_size
+        else:
+            self.reg_zero_pad = None
+            self._padded_prefix_len = self._prefix_len
+
+        # Transformer blocks
+        self.blocks = nn.ModuleList([instantiate(block_cfg) for _ in range(num_blocks)])
+
+        self.out_norm = instantiate(norm_cfg)
+        for param in self.out_norm.parameters():
+            param._no_weight_decay = True
+
+        self.dropout = nn.Dropout(dropout_rate) if dropout_rate > 0 else nn.Identity()
+
+        self._init_weights()
+
+    @staticmethod
+    def _normalize_nd_value(value: int | Sequence[int], data_dim: int, name: str) -> tuple[int, ...]:
+        if isinstance(value, int):
+            return (value,) * data_dim
+        value = tuple(value)
+        if len(value) != data_dim:
+            raise ValueError(f"{name} must have length {data_dim}, got {len(value)}")
+        return value
+
+    def _init_weights(self) -> None:
+        if self.cls_token is not None:
+            nn.init.trunc_normal_(self.cls_token, std=0.02)
+        if self.reg_token is not None:
+            nn.init.trunc_normal_(self.reg_token, std=0.02)
+        nn.init.trunc_normal_(self.pos_embed, std=0.02)
+
+    def _extract_patch_tokens(self, x: torch.Tensor) -> torch.Tensor:
+        start = self._padded_prefix_len
+        end = start + self.num_patches
+        return x[:, start:end, :]
+
+    def forward(self, input_and_condition: dict[str, torch.Tensor]) -> dict[str, torch.Tensor]:
+        """Forward pass.
+
+        Args:
+            input_and_condition: Dict with key ``input`` and optional ``condition``.
+
+        Returns:
+            Dict with dense prediction tensor in ``logits``.
+        """
+        # 1. Patchify density via input projecting mapper
+        x = input_and_condition["input"]
+        x = self.in_proj(x)
+
+        patch_grid_shape = tuple(x.shape[1:-1])
+        if patch_grid_shape != self.patch_grid_shape:
+            raise ValueError(
+                f"Runtime patch grid {patch_grid_shape} does not match configured shape {self.patch_grid_shape}."
+            )
+
+        # 2. Add absolute positional embeddings over the flattened sequence
+        batch_size = x.shape[0]
+        x = rearrange(x, "b ... c -> b (...) c")
+        x = x + self.pos_embed
+
+        # 3. Prepend CLS token (when enabled)
+        if self.cls_token is not None:
+            cls_tokens = self.cls_token.expand(batch_size, -1, -1)
+            x = torch.cat([cls_tokens, x], dim=1)
+
+        # 4. Insert register tokens
+        if self.reg_token is not None:
+            reg_tokens = self.reg_token.expand(batch_size, -1, -1)
+            if self.prepend_registers:
+                if self.cls_token is not None:
+                    # [CLS, regs, patches]
+                    x = torch.cat([x[:, :1, :], reg_tokens, x[:, 1:, :]], dim=1)
+                else:
+                    # [regs, patches]
+                    x = torch.cat([reg_tokens, x], dim=1)
+            else:
+                # [patches, regs] or [CLS, patches, regs]
+                x = torch.cat([x, reg_tokens], dim=1)
+
+        # 5. Automatically uniformly align prefix tokens (CLS + prepended registers) geometrically
+        # so ND sequential mixers reshape identically into N-planes.
+        if self.reg_zero_pad is not None:
+            pad = self.reg_zero_pad.expand(batch_size, -1, -1)
+            # [prefix, zero_pad, patches]
+            x = torch.cat([x[:, : self._prefix_len, :], pad, x[:, self._prefix_len :, :]], dim=1)
+
+        # 6. Apply transformer blocks
+        for block in self.blocks:
+            x = block(x)
+
+        # 7. Unpatchify dense representation filtering out CLS/Registers & optional zero padding
+        x = self._extract_patch_tokens(x)
+        x = self.out_norm(x)
+        x = self.dropout(x)
+        x = x.reshape(batch_size, *self.patch_grid_shape, self.hidden_dim)
+        x = self.out_proj(x)
+
+        return {"logits": x}


### PR DESCRIPTION
## Summary

- Adds `nvsubquadratic/networks/baselines/unet.py` — UNet baseline with Hyena/attention mixer support
- Adds `nvsubquadratic/networks/vit5_general_purpose.py` — ViT5-based general-purpose network with patchify/unpatchify

Split out from `wessels/clean-pde` for independent review.

## Known issues (from PR #73 review)

- **UNet**: `skips[0]` (finest-resolution encoder features) is never used in the decoder loop
- **UNet**: `_LayerNorm` channels_first branch performs L2 normalization, not LayerNorm
- **UNet**: `_build_hyena` pre-instantiates `SIRENKernelND(L_cache=spatial_res)` instead of passing a LazyConfig, bypassing `CKConvND`'s `L_cache` halving logic

## Test plan

- [ ] Review and address the known issues listed above
- [ ] Run `test_unet.py` and `test_unet_convnext_parity.py`
- [ ] Verify example configs that depend on these networks still work

Made with [Cursor](https://cursor.com)