### PR TITLE
fix: resolve test failures for quack unavailability and h5 caching

### DIFF
--- a/nvsubquadratic/modules/mlp.py
+++ b/nvsubquadratic/modules/mlp.py
@@ -120,12 +120,6 @@ def _validate_quack_backend(
     hidden_dim: int,
 ) -> None:
     """Raise ``ValueError`` at init time if QuACK constraints are not met."""
-    raise NotImplementedError(
-        "MLP backend='quack' is experimental and needs more testing "
-        "(forward correctness verified, backward + benchmark pending). "
-        "Use backend='torch' for now."
-    )
-
     min_ver = ".".join(str(v) for v in _QUACK_MLP_MIN_VERSION)
 
     if not _quack_mlp_available:
@@ -140,6 +134,12 @@ def _validate_quack_backend(
             f"but it is not installed. "
             f"Run: pip install quack-kernels"
         )
+
+    raise NotImplementedError(
+        "MLP backend='quack' is experimental and needs more testing "
+        "(forward correctness verified, backward + benchmark pending). "
+        "Use backend='torch' for now."
+    )
 
     if activation not in _QUACK_ACT_MAP:
         raise ValueError(

--- a/tests/test_h5_caching.py
+++ b/tests/test_h5_caching.py
@@ -7,7 +7,10 @@ Run with:
     conda run -n nv-subq python -m pytest tests/test_h5_caching.py -v
 """
 
+import os
+
 import numpy as np
+import pytest
 import torch
 from the_well.data.datasets import WellDataset
 
@@ -18,6 +21,11 @@ WELL_BASE = "/shared/data/image_datasets/the_well/datasets"
 DATASET = "gray_scott_reaction_diffusion"
 SPLIT = "valid"
 SAMPLE_INDICES = [0, 1, 42, 100]
+
+pytestmark = pytest.mark.skipif(
+    not os.path.isdir(os.path.join(WELL_BASE, DATASET)),
+    reason=f"No HDF5 files found in path {os.path.join(WELL_BASE, DATASET)} — dataset not available",
+)
 
 
 def _make_dataset():


### PR DESCRIPTION
## Summary

- **`test_quack_backend_unavailable_gives_clear_error`**: `_validate_quack_backend` was raising `NotImplementedError` before reaching the availability check, so the test received the wrong exception type. Moved the `_quack_mlp_available` guard before the `NotImplementedError` — unavailability now correctly raises `ValueError("...quack-kernels...")`.
- **`test_h5_caching.*`**: Added `pytestmark = pytest.mark.skipif(...)` so all three caching tests skip cleanly when the Gray-Scott dataset directory isn't present, rather than failing with a confusing `AssertionError`.