### PR TITLE
feat: v5 ImageNet configs with patch-size ablation support

### DIFF
--- a/examples/vit5_imagenet/v5/TRACKER.md
+++ b/examples/vit5_imagenet/v5/TRACKER.md
@@ -1,0 +1,64 @@
+# ViT-5-Small ImageNet-1k — v5 Patch-Size Ablation
+
+## Goal
+
+Ablate patch size (2, 4, 8, 16) for **Attention** and **Hyena + Gaussian mask**
+on ImageNet-1k pretraining. All runs share the same training recipe (800 epochs,
+LAMB lr=4e-3, wd=0.05, cosine schedule, 3-Augment, Mixup/CutMix, EMA 0.99996).
+
+The effective batch size is held constant at **2048** across all patch sizes.
+Per-GPU batch size is 256; if a configuration OOMs at batch 256, gradient
+accumulation is used to maintain the effective batch size (e.g. micro-batch 128
+with 2 accumulation steps per GPU, or 64 with 4 steps).
+
+## Configs
+
+| File                             | Model                       | Compile                    | FFT backend |
+| -------------------------------- | --------------------------- | -------------------------- | ----------- |
+| `attention_pretrain.py`          | ViT5Attention (CLS, 4 regs) | max-autotune               | —           |
+| `hyena_gap_gaussian_pretrain.py` | Hyena + Gaussian mask (GAP) | max-autotune-no-cudagraphs | subq_ops    |
+
+## Patch-size overrides
+
+`num_patches_h`, `num_patches_w` (Attention) and `grid_w`, `L_cache` (Hyena) are
+computed dynamically via `${eval:'${net.image_size} // ${net.patch_size}'}` interpolators.
+Only `net.patch_size` needs to be overridden:
+
+```
+net.patch_size=P
+```
+
+If OOM at batch 256, add: `dataset.batch_size=<micro_batch>  trainer.accumulate_grad_batches=<accum_steps>`
+(keep `micro_batch * accum_steps * num_gpus = 2048`).
+
+## Results — Attention
+
+| Patch | Tokens/img | Batch/GPU | Grad Accum | GPUs | WandB Run | val/acc_ema | it/s (1 GPU) |
+| ----- | ---------- | --------- | ---------- | ---- | --------- | ----------- | ------------ |
+| 16    | 196        | 256       | 1          | 8    |           |             | 8.5          |
+| 8     | 784        | 256       | 1          | 8    |           |             | 5.2          |
+| 4     | 3,136      | 64        | 4          | 8    |           |             | —            |
+| 2     | 12,544     | 16        | 16         | 8    |           |             | —            |
+
+## Results — Hyena + Gaussian Mask (subq_ops)
+
+| Patch | Tokens/img | Batch/GPU | Grad Accum | GPUs | WandB Run | val/acc_ema | it/s (1 GPU) |
+| ----- | ---------- | --------- | ---------- | ---- | --------- | ----------- | ------------ |
+| 16    | 196        | 256       | 1          | 8    |           |             | 7.3          |
+| 8     | 784        | 256       | 1          | 8    |           |             | 5.1          |
+| 4     | 3,136      | 64        | 4          | 8    |           |             | —            |
+| 2     | 12,544     | 16        | 16         | 8    |           |             | —            |
+
+## Memory Probing Notes (1×H100 80GB, with torch.compile)
+
+Attention uses `max-autotune` (CUDA graphs); Hyena+G uses `max-autotune-no-cudagraphs` + `subq_ops`.
+Both models OOM at the same batch thresholds despite different compile modes.
+
+| Patch | Batch 256         | Batch 128  | Batch 64      | Batch 32   | Batch 16      |
+| ----- | ----------------- | ---------- | ------------- | ---------- | ------------- |
+| 16    | Attn OK, Hyena OK | —          | —             | —          | —             |
+| 8     | Attn OK, Hyena OK | —          | —             | —          | —             |
+| 4     | OOM (both)        | OOM (both) | **OK (both)** | —          | —             |
+| 2     | OOM (both)        | —          | —             | OOM (both) | **OK (both)** |
+
+Grad accumulation set so `batch * accum * 8 GPUs = 2048`.

--- a/examples/vit5_imagenet/v5/_base.py
+++ b/examples/vit5_imagenet/v5/_base.py
@@ -1,0 +1,206 @@
+"""ViT-5-Small ImageNet-1k pretraining — v5 shared training recipe.
+
+This base owns everything **except** the network: dataset, optimizer,
+scheduler, callbacks, wandb, auto-resume, and training loop settings.
+
+Instance configs (e.g. ``attention_pretrain.py``, ``hyena_gap_pretrain.py``)
+call ``get_base_config(...)`` to get a pre-filled ExperimentConfig, then
+set ``config.net`` and compile flags.
+
+Training recipe (shared defaults):
+- 800 epochs, batch 256/GPU, effective batch 2048 (8 GPUs)
+- Optimizer: Apex FusedLAMB, lr=4e-3, wd=0.05, grad_clip=1.0
+- Scheduler: Cosine with 5-epoch warmup
+- EMA decay 0.99996, SoftTargetCE loss, bf16-mixed
+- 3-Augment, Mixup 0.8, CutMix 1.0
+- DALI fused data pipeline with local NVMe staging
+"""
+
+import os
+
+from apex.optimizers import FusedLAMB as Lamb
+
+from experiments.callbacks.iteration_speed import IterationSpeedCallback
+from experiments.callbacks.model_ema import LabeledEMAWeightAveraging
+from experiments.datamodules.dali_imagenet_fused import (
+    AugmentConfig,
+    DALIImageNetFusedDataModule,
+    MixupConfig,
+)
+from experiments.default_cfg import (
+    AutoResumeConfig,
+    ExperimentConfig,
+    SchedulerConfig,
+    TrainConfig,
+    TrainerConfig,
+    WandbConfig,
+)
+from experiments.lightning_wrappers.classification_wrapper import ClassificationWrapper
+from nvsubquadratic.lazy_config import PLACEHOLDER, LazyConfig
+
+
+# ─── Dataset constants ───────────────────────────────────────────────────────────
+INPUT_CHANNELS = 3
+NUM_CLASSES = 1000
+IMAGE_SIZE = 224
+FINAL_IMAGE_SIZE = 224
+IMAGENET_PATH = os.environ.get("IMAGENET_PATH", "/shared/data/image_datasets/imagenet")
+IMAGENET_FOLDER_PATH = os.environ.get("IMAGENET_FOLDER_PATH", "/shared/data/image_datasets/imagenet_folder")
+
+# ─── Model constants (shared across mixers) ─────────────────────────────────────
+HIDDEN_DIM = 384
+NUM_BLOCKS = 12
+PATCH_SIZE = 16
+NUM_PATCHES_H = FINAL_IMAGE_SIZE // PATCH_SIZE  # 14
+NUM_PATCHES_W = FINAL_IMAGE_SIZE // PATCH_SIZE  # 14
+LAYER_SCALE_INIT = 1e-4
+MLP_RATIO = 4
+
+# ─── Training recipe ────────────────────────────────────────────────────────────
+BATCH_SIZE = 256
+EPOCHS = 800
+IMAGENET_TRAIN_SIZE = 1_281_167
+EFFECTIVE_BATCH_SIZE = 2048
+ITERS_PER_EPOCH = IMAGENET_TRAIN_SIZE // EFFECTIVE_BATCH_SIZE
+TOTAL_ITERATIONS = EPOCHS * ITERS_PER_EPOCH
+WARMUP_EPOCHS = 5
+WARMUP_ITERATIONS_PERCENTAGE = WARMUP_EPOCHS / EPOCHS
+
+LEARNING_RATE = 4e-3
+WEIGHT_DECAY = 0.05
+GRAD_CLIP = 1.0
+PRECISION = "bf16-mixed"
+NUM_WORKERS = 12
+
+
+def get_base_config(
+    *,
+    lr: float = LEARNING_RATE,
+    wd: float = WEIGHT_DECAY,
+    epochs: int = EPOCHS,
+    grad_clip: float = GRAD_CLIP,
+    ema_decay: float = 0.99996,
+    # ─── Augmentation ────────────────────────────────────────────────
+    mixup: float = 0.8,
+    cutmix: float = 1.0,
+    smoothing: float = 0.0,
+    use_three_augment: bool = True,
+    color_jitter: float = 0.3,
+    rand_augment: str | None = None,
+    random_erasing_prob: float = 0.0,
+    num_repeats: int = 1,
+    # ─── Extra callbacks ─────────────────────────────────────────────
+    extra_callbacks: list | None = None,
+) -> ExperimentConfig:
+    """Return a config with everything except ``config.net`` and compile flags.
+
+    Args:
+        lr: Learning rate for LAMB.
+        wd: Global weight decay.
+        epochs: Number of pretraining epochs.
+        grad_clip: Gradient clipping norm.
+        ema_decay: EMA decay rate.
+        mixup: Mixup alpha (0.0 = disabled).
+        cutmix: CutMix alpha (0.0 = disabled).
+        smoothing: Label smoothing.
+        use_three_augment: Use three-augment instead of RandAugment.
+        color_jitter: Color jitter factor.
+        rand_augment: RandAugment config string (when ``use_three_augment=False``).
+        random_erasing_prob: Random erasing probability.
+        num_repeats: Repeated augmentation factor (1 = disabled).
+        extra_callbacks: Additional callbacks appended after EMA + IterationSpeed.
+    """
+    config = ExperimentConfig()
+    config.debug = False
+    config.seed = 42
+    config.num_blocks = NUM_BLOCKS
+
+    # ─── Dataset (fused DALI + local NVMe staging) ───────────────────
+    config.dataset = LazyConfig(DALIImageNetFusedDataModule)(
+        data_dir=IMAGENET_PATH,
+        imagefolder_dir=IMAGENET_FOLDER_PATH,
+        prefetch_factor=3,
+        batch_size=BATCH_SIZE,
+        num_workers=NUM_WORKERS,
+        pin_memory=True,
+        seed=config.seed,
+        image_size=IMAGE_SIZE,
+        final_image_size=FINAL_IMAGE_SIZE,
+        num_classes=NUM_CLASSES,
+        drop_labels=False,
+        task="classification",
+        mixup_cfg=LazyConfig(MixupConfig)(
+            mixup=mixup,
+            cutmix=cutmix,
+            mixup_prob=1.0,
+            mixup_switch_prob=0.5,
+            mixup_mode="batch",
+            smoothing=smoothing,
+        ),
+        augment_cfg=LazyConfig(AugmentConfig)(
+            use_three_augment=use_three_augment,
+            color_jitter=color_jitter,
+            rand_augment=rand_augment,
+            random_erasing_prob=random_erasing_prob,
+            random_erasing_mode="pixel",
+            num_repeats=num_repeats,
+        ),
+        device_id=0,
+        local_staging_dir=f"/scratch/{os.environ.get('USER', 'unknown')}/imagenet_dataset",
+    )
+
+    # ─── Lightning wrapper ───────────────────────────────────────────
+    config.lightning_wrapper_class = LazyConfig(ClassificationWrapper)(loss="soft_target_ce")
+
+    # ─── Optimizer (Apex FusedLAMB) ──────────────────────────────────
+    config.optimizer = LazyConfig(Lamb)(
+        params=PLACEHOLDER,
+        lr=lr,
+        weight_decay=wd,
+    )
+
+    # ─── Training ────────────────────────────────────────────────────
+    total_iters = epochs * ITERS_PER_EPOCH
+    config.train = TrainConfig(
+        batch_size="${dataset.batch_size}",
+        iterations=total_iters,
+        grad_clip=grad_clip,
+        precision=PRECISION,
+    )
+
+    config.trainer = TrainerConfig(
+        check_val_every_n_epoch=4,
+        checkpoint_every_n_steps=5000,
+        checkpoint_monitor="val/acc_ema",
+    )
+
+    # ─── Scheduler (cosine, warmup) ──────────────────────────────────
+    config.scheduler = SchedulerConfig(
+        name="cosine",
+        warmup_iterations_percentage=WARMUP_ITERATIONS_PERCENTAGE,
+        total_iterations="${train.iterations}",
+        mode="max",
+    )
+
+    # ─── Wandb ───────────────────────────────────────────────────────
+    config.wandb = WandbConfig(
+        job_group="imagenet_v5_pretrain",
+        entity="implicit-long-convs",
+        project="nvsubquadratic",
+    )
+
+    # ─── Auto-resume ─────────────────────────────────────────────────
+    config.autoresume = AutoResumeConfig(enabled=False)
+
+    # ─── Callbacks ───────────────────────────────────────────────────
+    config.callbacks = [
+        LazyConfig(LabeledEMAWeightAveraging)(decay=ema_decay),
+        LazyConfig(IterationSpeedCallback)(
+            log_every_n_steps=10,
+            batch_size_per_gpu=BATCH_SIZE,
+        ),
+    ]
+    if extra_callbacks:
+        config.callbacks.extend(extra_callbacks)
+
+    return config

--- a/examples/vit5_imagenet/v5/attention_pretrain.py
+++ b/examples/vit5_imagenet/v5/attention_pretrain.py
@@ -1,0 +1,94 @@
+"""ViT-5-Small attention baseline — best pretraining config.
+
+Reproduces run 44or24g1 (82.22% val/acc_ema, 82.22% test):
+- ViT5Attention (6 heads, RoPE, RMSNorm QK-norm), CLS readout, 4 registers
+- trunc_normal(std=0.02) init, no biases (qkv, out_proj, MLP)
+- SoftTargetCE loss, EMA decay=0.99996
+- LAMB lr=4e-3, wd=0.05, cosine schedule, 800 epochs
+- 3-Augment + Mixup 0.8 + CutMix 1.0, DropPath 0.05
+"""
+
+import torch
+
+from examples.vit5_imagenet.v5._base import (
+    FINAL_IMAGE_SIZE,
+    HIDDEN_DIM,
+    INPUT_CHANNELS,
+    LAYER_SCALE_INIT,
+    MLP_RATIO,
+    NUM_BLOCKS,
+    NUM_CLASSES,
+    PATCH_SIZE,
+    get_base_config,
+)
+from experiments.default_cfg import ExperimentConfig
+from nvsubquadratic.lazy_config import LazyConfig
+from nvsubquadratic.modules.mlp import MLP
+from nvsubquadratic.modules.rms_norm import RMSNorm
+from nvsubquadratic.modules.vit5_attention import ViT5Attention
+from nvsubquadratic.modules.vit5_residual_block import ViT5ResidualBlock
+from nvsubquadratic.networks.vit5_classification import ViT5ClassificationNet
+from nvsubquadratic.utils.init import trunc_normal_init, trunc_normal_init_factory
+
+
+NUM_HEADS = 6
+NUM_REGISTERS = 4
+DROP_PATH_RATE = 0.05
+
+_INIT_FN = trunc_normal_init(std=0.02)
+_INIT_FN_FACTORY = trunc_normal_init_factory(std=0.02)
+
+
+def get_config() -> ExperimentConfig:
+    """Build ViT-5-Small attention pretraining config."""
+    config = get_base_config()
+
+    config.compile = True
+    config.compile_mode = "max-autotune"
+
+    config.net = LazyConfig(ViT5ClassificationNet)(
+        in_channels=INPUT_CHANNELS,
+        num_classes=NUM_CLASSES,
+        hidden_dim=HIDDEN_DIM,
+        num_blocks=NUM_BLOCKS,
+        patch_size=PATCH_SIZE,
+        image_size=FINAL_IMAGE_SIZE,
+        num_registers=NUM_REGISTERS,
+        dropout_rate=0.0,
+        readout="cls",
+        norm_cfg=LazyConfig(RMSNorm)(dim=HIDDEN_DIM, eps=1e-6),
+        block_cfg=LazyConfig(ViT5ResidualBlock)(
+            sequence_mixer_cfg=LazyConfig(ViT5Attention)(
+                hidden_dim=HIDDEN_DIM,
+                num_heads=NUM_HEADS,
+                num_patches_h="${eval:'${net.image_size} // ${net.patch_size}'}",
+                num_patches_w="${eval:'${net.image_size} // ${net.patch_size}'}",
+                num_registers=NUM_REGISTERS,
+                qk_norm=LazyConfig(RMSNorm)(dim=HIDDEN_DIM // NUM_HEADS, eps=1e-6),
+                rope_base=10000.0,
+                reg_rope_base=100.0,
+                attn_dropout=0.0,
+                proj_dropout=0.0,
+                qkv_bias=False,
+                out_proj_bias=False,
+                init_fn_qkv_proj=_INIT_FN,
+                init_fn_out_proj=_INIT_FN,
+            ),
+            sequence_mixer_norm_cfg=LazyConfig(RMSNorm)(dim=HIDDEN_DIM, eps=1e-6),
+            mlp_cfg=LazyConfig(MLP)(
+                dim=HIDDEN_DIM,
+                activation="gelu",
+                expansion_factor=float(MLP_RATIO),
+                bias=False,
+                dropout_cfg=LazyConfig(torch.nn.Dropout)(p=0.0),
+                init_method_in=_INIT_FN_FACTORY,
+                init_method_out=_INIT_FN_FACTORY,
+            ),
+            mlp_norm_cfg=LazyConfig(RMSNorm)(dim=HIDDEN_DIM, eps=1e-6),
+            hidden_dim=HIDDEN_DIM,
+            layer_scale_init=LAYER_SCALE_INIT,
+            drop_path_rate=DROP_PATH_RATE,
+        ),
+    )
+
+    return config

--- a/examples/vit5_imagenet/v5/hyena_gap_gaussian_pretrain.py
+++ b/examples/vit5_imagenet/v5/hyena_gap_gaussian_pretrain.py
@@ -1,0 +1,29 @@
+"""ViT-5-Small Hyena GAP gated + Gaussian mask — pretraining config.
+
+Same architecture as hyena_gap_pretrain.py but with a learnable
+GaussianModulationND mask on the SIREN kernel output instead of Identity.
+"""
+
+from examples.vit5_imagenet.v5._base import HIDDEN_DIM
+from examples.vit5_imagenet.v5.hyena_gap_pretrain import get_config as _hyena_gap
+from experiments.callbacks.mask_monitor import MaskMonitorCallback
+from experiments.default_cfg import ExperimentConfig
+from nvsubquadratic.lazy_config import LazyConfig
+from nvsubquadratic.modules.masks_nd import GaussianModulationND
+
+
+def get_config() -> ExperimentConfig:
+    """Build Hyena GAP gated + Gaussian mask pretraining config."""
+    config = _hyena_gap()
+    config.net.block_cfg.sequence_mixer_cfg.inner_mixer_cfg.mixer_cfg.global_conv_cfg.mask_cfg = LazyConfig(
+        GaussianModulationND
+    )(
+        data_dim=2,
+        num_channels=HIDDEN_DIM,
+        min_attenuation_at_step=0.1,
+        max_attenuation_at_limit=0.95,
+        init_extent=1.0,
+        parametrization="direct",
+    )
+    config.callbacks.append(LazyConfig(MaskMonitorCallback)(log_every_n_steps=50))
+    return config

--- a/examples/vit5_imagenet/v5/hyena_gap_pretrain.py
+++ b/examples/vit5_imagenet/v5/hyena_gap_pretrain.py
@@ -1,0 +1,130 @@
+"""ViT-5-Small Hyena GAP gated — best GAP pretraining config.
+
+Reproduces run tcji9tfx (81.50% val/acc_ema, 81.49% test):
+- Hyena mixer: SiLU 1st gate + Sigmoid 2nd gate, output RMSNorm, L2 QK-norm
+- SIREN kernel: 3-layer, hidden_dim=32, embedding_dim=32, omega_0=10.0
+- GAP readout (no CLS token, no registers)
+- SoftTargetCE loss, EMA decay=0.99996
+- LAMB lr=4e-3, wd=0.05, cosine schedule, 800 epochs
+- 3-Augment + Mixup 0.8 + CutMix 1.0, DropPath 0.05
+"""
+
+import torch
+
+from examples.vit5_imagenet.v5._base import (
+    FINAL_IMAGE_SIZE,
+    HIDDEN_DIM,
+    INPUT_CHANNELS,
+    LAYER_SCALE_INIT,
+    MLP_RATIO,
+    NUM_BLOCKS,
+    NUM_CLASSES,
+    PATCH_SIZE,
+    get_base_config,
+)
+from experiments.default_cfg import ExperimentConfig
+from nvsubquadratic.lazy_config import LazyConfig
+from nvsubquadratic.modules.ckconv_nd import CKConvND
+from nvsubquadratic.modules.hyena_nd import Hyena
+from nvsubquadratic.modules.kernels_nd import SIRENKernelND
+from nvsubquadratic.modules.mlp import MLP
+from nvsubquadratic.modules.rms_norm import RMSNorm
+from nvsubquadratic.modules.sequence_mixer import QKVSequenceMixer
+from nvsubquadratic.modules.vit5_hyena_adapter import ViT5HyenaAdapter
+from nvsubquadratic.modules.vit5_residual_block import ViT5ResidualBlock
+from nvsubquadratic.networks.vit5_classification import ViT5ClassificationNet
+from nvsubquadratic.utils.init import partial_wang_init_fn_with_num_layers, small_init
+from nvsubquadratic.utils.qk_norm import L2Norm
+
+
+DROP_PATH_RATE = 0.05
+
+# ─── SIREN kernel hyperparameters ────────────────────────────────────────────────
+KERNEL_MLP_HIDDEN_DIM = 32
+KERNEL_NUM_LAYERS = 3
+KERNEL_EMBEDDING_DIM = 32
+KERNEL_OMEGA_0 = 10.0
+KERNEL_HIDDEN_OMEGA_0 = 1.0
+
+
+def get_config() -> ExperimentConfig:
+    """Build ViT-5-Small Hyena GAP gated pretraining config."""
+    config = get_base_config()
+
+    config.compile = True
+    config.compile_mode = "max-autotune-no-cudagraphs"
+
+    hyena_mixer_cfg = LazyConfig(QKVSequenceMixer)(
+        hidden_dim=HIDDEN_DIM,
+        mixer_cfg=LazyConfig(Hyena)(
+            global_conv_cfg=LazyConfig(CKConvND)(
+                data_dim=2,
+                hidden_dim=HIDDEN_DIM,
+                kernel_cfg=LazyConfig(SIRENKernelND)(
+                    data_dim=2,
+                    out_dim=HIDDEN_DIM,
+                    mlp_hidden_dim=KERNEL_MLP_HIDDEN_DIM,
+                    num_layers=KERNEL_NUM_LAYERS,
+                    embedding_dim=KERNEL_EMBEDDING_DIM,
+                    omega_0=KERNEL_OMEGA_0,
+                    L_cache="${eval:'${net.image_size} // ${net.patch_size}'}",
+                    use_bias=True,
+                    hidden_omega_0=KERNEL_HIDDEN_OMEGA_0,
+                ),
+                mask_cfg=LazyConfig(torch.nn.Identity)(),
+                grid_type="double",
+                fft_padding="zero",
+                fft_backend="subq_ops",
+            ),
+            short_conv_cfg=LazyConfig(torch.nn.Conv2d)(
+                in_channels=3 * HIDDEN_DIM,
+                out_channels=3 * HIDDEN_DIM,
+                kernel_size=3,
+                groups=3 * HIDDEN_DIM,
+                padding=1,
+                bias=False,
+            ),
+            gate_nonlinear_cfg=LazyConfig(torch.nn.SiLU)(),
+            pixelhyena_norm_cfg=LazyConfig(RMSNorm)(dim=HIDDEN_DIM, eps=1e-6),
+            qk_norm_cfg=LazyConfig(L2Norm)(),
+            use_rope=False,
+            output_norm_cfg=LazyConfig(RMSNorm)(dim=HIDDEN_DIM, eps=1e-6),
+            gate_nonlinear_2_cfg=LazyConfig(torch.nn.Sigmoid)(),
+        ),
+        init_method_in=small_init,
+        init_method_out=LazyConfig(partial_wang_init_fn_with_num_layers)(num_layers=NUM_BLOCKS),
+    )
+
+    config.net = LazyConfig(ViT5ClassificationNet)(
+        in_channels=INPUT_CHANNELS,
+        num_classes=NUM_CLASSES,
+        hidden_dim=HIDDEN_DIM,
+        num_blocks=NUM_BLOCKS,
+        patch_size=PATCH_SIZE,
+        image_size=FINAL_IMAGE_SIZE,
+        num_registers=0,
+        dropout_rate=0.0,
+        readout="gap",
+        norm_cfg=LazyConfig(RMSNorm)(dim=HIDDEN_DIM, eps=1e-6),
+        block_cfg=LazyConfig(ViT5ResidualBlock)(
+            sequence_mixer_cfg=LazyConfig(ViT5HyenaAdapter)(
+                inner_mixer_cfg=hyena_mixer_cfg,
+                grid_w="${eval:'${net.image_size} // ${net.patch_size}'}",
+            ),
+            sequence_mixer_norm_cfg=LazyConfig(RMSNorm)(dim=HIDDEN_DIM, eps=1e-6),
+            mlp_cfg=LazyConfig(MLP)(
+                dim=HIDDEN_DIM,
+                activation="gelu",
+                expansion_factor=float(MLP_RATIO),
+                dropout_cfg=LazyConfig(torch.nn.Dropout)(p=0.0),
+                init_method_in=small_init,
+                init_method_out=LazyConfig(partial_wang_init_fn_with_num_layers)(num_layers=NUM_BLOCKS),
+            ),
+            mlp_norm_cfg=LazyConfig(RMSNorm)(dim=HIDDEN_DIM, eps=1e-6),
+            hidden_dim=HIDDEN_DIM,
+            layer_scale_init=LAYER_SCALE_INIT,
+            drop_path_rate=DROP_PATH_RATE,
+        ),
+    )
+
+    return config


### PR DESCRIPTION
## Summary

- Adds modular v5 config hierarchy for ViT-5-Small ImageNet-1k pretraining: shared base recipe (`_base.py`), attention baseline (`attention_pretrain.py`), Hyena GAP (`hyena_gap_pretrain.py`), and Hyena GAP + Gaussian mask (`hyena_gap_gaussian_pretrain.py`).
- Patch-derived fields (`num_patches_h/w`, `grid_w`, `L_cache`) use `${eval:...}` interpolators — only `net.patch_size` needs overriding for different resolutions.
- Includes `TRACKER.md` with the patch-size ablation plan (p16/p8/p4/p2) for both Attention and Hyena+Gaussian, along with memory probing results (batch size / grad accumulation settings per patch size on 1×H100 80GB).

## Configs

| File | Model | Compile | FFT backend |
|---|---|---|---|
| `attention_pretrain.py` | ViT5Attention (CLS, 4 regs) | max-autotune | — |
| `hyena_gap_gaussian_pretrain.py` | Hyena + Gaussian mask (GAP) | max-autotune-no-cudagraphs | subq_ops |

## Memory probing (1×H100 80GB, torch.compile)

| Patch | Batch/GPU | Grad Accum | Effective Batch |
|-------|-----------|------------|-----------------|
| 16 | 256 | 1 | 2048 |
| 8 | 256 | 1 | 2048 |
| 4 | 64 | 4 | 2048 |
| 2 | 16 | 16 | 2048 |

## Test plan

- [x] Verify `${eval:...}` interpolators resolve correctly for all patch sizes (p16, p8, p4, p2)
- [x] Confirm attention config matches best historical run (44or24g1)
- [x] Memory probe: Attention p4 b64 fits, p2 b16 fits
- [x] Memory probe: Hyena+G p4 b64 fits, p2 b16 fits
- [x] Pre-commit hooks passed (ruff, mdformat, detect-secrets)