### PR TITLE
feat: hybrid ViT-5 architecture with interleaved Hyena/Attention blocks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+# Slurm outputs
+slurm-*.out
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/examples/vit5_imagenet/v3/gap_film_regs/_base.py
+++ b/examples/vit5_imagenet/v3/gap_film_regs/_base.py
@@ -258,12 +258,12 @@ def get_config(
         init_method_out=LazyConfig(partial_wang_init_fn_with_num_layers)(num_layers=NUM_BLOCKS),
     )
 
-    # Block config: add register pooling when FiLM is enabled
+    # Block config: add register pooling when FiLM is enabled.
+    # register_start_idx is auto-computed by ViT5ClassificationNet from the token layout.
     block_kwargs = {}
     if has_film:
         block_kwargs["register_pooling_cfg"] = LazyConfig(RegisterPooling)(num_registers=num_registers)
         block_kwargs["num_registers"] = num_registers
-        block_kwargs["register_start_idx"] = 0  # GAP model: no CLS, registers at position 0
 
     config.net = LazyConfig(ViT5ClassificationNet)(
         in_channels=INPUT_CHANNELS,
@@ -275,7 +275,6 @@ def get_config(
         num_registers=num_registers if has_film else 0,
         dropout_rate=0.0,
         readout="gap",
-        prepend_registers=True if has_film else False,
         norm_cfg=LazyConfig(RMSNorm)(dim=HIDDEN_DIM, eps=1e-6),
         block_cfg=LazyConfig(ViT5ResidualBlock)(
             sequence_mixer_cfg=LazyConfig(ViT5HyenaAdapter)(

--- a/examples/vit5_imagenet/vit5_hybrid/TRACKER.md
+++ b/examples/vit5_imagenet/vit5_hybrid/TRACKER.md
@@ -1,0 +1,69 @@
+# ViT-5-Small ImageNet-1k — Hybrid (Interleaved Hyena + Attention)
+
+## Goal
+
+Ablate the ratio of Hyena-to-Attention layers in a hybrid ViT-5-Small on
+ImageNet-1k pretraining.  All runs share the v5 training recipe (800 epochs,
+LAMB lr=4e-3, wd=0.05, cosine schedule, 3-Augment, Mixup/CutMix, EMA 0.99996).
+
+Key differences from v5:
+
+- Uniform trunc_normal(std=0.02) initialization for **all** layer types.
+- No FiLM. Learnable `GaussianModulationND` mask on Hyena kernel output.
+- CLS readout with 4 registers for all configs.
+- Token layout: `[patches, CLS, registers, padding]`.
+  Padding is stripped for Attention blocks and kept for Hyena blocks.
+- GRN (Global Response Normalization) on Hyena blocks.
+
+## Configs
+
+| File                | Pattern    | Hyena:Attn | Compile                    |
+| ------------------- | ---------- | ---------- | -------------------------- |
+| `full_attention.py` | `A×12`     | 0:12       | max-autotune-no-cudagraphs |
+| `hybrid_ha.py`      | `(HA)×6`   | 6:6        | max-autotune-no-cudagraphs |
+| `hybrid_hhha.py`    | `(HHHA)×3` | 9:3        | max-autotune-no-cudagraphs |
+| `full_hyena.py`     | `H×12`     | 12:0       | max-autotune-no-cudagraphs |
+
+All configs are patch-size agnostic. Override `net.patch_size=P` to change
+resolution (default 16).
+
+______________________________________________________________________
+
+## Patch 16
+
+196 tokens/image.
+
+| Config                | Params (M) | GFLOPs (train) |
+| --------------------- | ---------- | -------------- |
+| Full Attention (A×12) | 22.01      | 9.41           |
+| Hybrid HA (HA×6)      | 22.17      | 9.69           |
+| Hybrid HHHA (HHHA×3)  | 22.25      | 9.84           |
+| Full Hyena (H×12)     | 22.33      | 9.98           |
+
+| Config                | WandB Run | val/acc_ema | test/acc | it/s (1 GPU) |
+| --------------------- | --------- | ----------- | -------- | ------------ |
+| Full Attention (A×12) |           |             |          |              |
+| Hybrid HA (HA×6)      |           |             |          |              |
+| Hybrid HHHA (HHHA×3)  |           |             |          |              |
+| Full Hyena (H×12)     |           |             |          |              |
+
+______________________________________________________________________
+
+## Patch 8
+
+784 tokens/image. Replacing Attention with Hyena saves significant FLOPs:
+Full Hyena is **14.3% cheaper** than Full Attention (38.72 vs 45.16 GFLOPs).
+
+| Config                | Params (M) | GFLOPs (train) |
+| --------------------- | ---------- | -------------- |
+| Full Attention (A×12) | 22.01      | 45.16          |
+| Hybrid HA (HA×6)      | 22.18      | 41.94          |
+| Hybrid HHHA (HHHA×3)  | 22.26      | 40.33          |
+| Full Hyena (H×12)     | 22.34      | 38.72          |
+
+| Config                | WandB Run | val/acc_ema | test/acc | it/s (1 GPU) |
+| --------------------- | --------- | ----------- | -------- | ------------ |
+| Full Attention (A×12) |           |             |          |              |
+| Hybrid HA (HA×6)      |           |             |          |              |
+| Hybrid HHHA (HHHA×3)  |           |             |          |              |
+| Full Hyena (H×12)     |           |             |          |              |

--- a/examples/vit5_imagenet/vit5_hybrid/_base_config.py
+++ b/examples/vit5_imagenet/vit5_hybrid/_base_config.py
@@ -136,7 +136,7 @@ def _make_hyena_block_cfg() -> LazyConfig:
                 data_dim=2,
                 hidden_dim="${net.hidden_dim}",
                 kernel_cfg=LazyConfig(SIRENKernelND)(
-                    data_dim=2,
+                    data_dim="${net.layer_types.H.sequence_mixer_cfg.inner_mixer_cfg.mixer_cfg.global_conv_cfg.data_dim}",
                     out_dim="${net.hidden_dim}",
                     mlp_hidden_dim=KERNEL_MLP_HIDDEN_DIM,
                     num_layers=KERNEL_NUM_LAYERS,
@@ -147,7 +147,7 @@ def _make_hyena_block_cfg() -> LazyConfig:
                     hidden_omega_0=KERNEL_HIDDEN_OMEGA_0,
                 ),
                 mask_cfg=LazyConfig(GaussianModulationND)(
-                    data_dim=2,
+                    data_dim="${net.layer_types.H.sequence_mixer_cfg.inner_mixer_cfg.mixer_cfg.global_conv_cfg.data_dim}",
                     num_channels="${net.hidden_dim}",
                     min_attenuation_at_step=0.1,
                     max_attenuation_at_limit=0.95,

--- a/examples/vit5_imagenet/vit5_hybrid/_base_config.py
+++ b/examples/vit5_imagenet/vit5_hybrid/_base_config.py
@@ -1,0 +1,251 @@
+"""Shared base config for hybrid ViT-5 experiments: interleaved Hyena + Attention.
+
+Reuses the training recipe, dataset, and model constants from the v5 base.
+Adds ``build_hybrid_net`` which produces a ``ViT5ClassificationNet`` with a
+``layer_pattern`` + ``layer_types`` dict for interleaved block stacking.
+
+All layers use trunc_normal(std=0.02) initialization uniformly.
+Hyena blocks use a learnable GaussianModulationND mask on the SIREN kernel output.
+
+Patch-size-dependent quantities (``num_patches_h/w``, ``grid_w``, ``L_cache``)
+use ``"${eval:'${net.image_size} // ${net.patch_size}'}"`` interpolations that
+reference the top-level network config keys.  This means ``patch_size`` is the
+sole source of truth — changing it on the network config automatically updates
+every derived value at ``OmegaConf.resolve()`` time.
+
+Typical usage::
+
+    config.net = build_hybrid_net(layer_pattern="HA" * 6, patch_size=16)
+"""
+
+import torch
+
+from examples.vit5_imagenet.v5._base import (
+    FINAL_IMAGE_SIZE,
+    HIDDEN_DIM,
+    INPUT_CHANNELS,
+    LAYER_SCALE_INIT,
+    MLP_RATIO,
+    NUM_BLOCKS,
+    NUM_CLASSES,
+    PATCH_SIZE,
+    get_base_config,
+)
+from nvsubquadratic.lazy_config import LazyConfig
+from nvsubquadratic.modules.ckconv_nd import CKConvND
+from nvsubquadratic.modules.grn import GlobalResponseNorm
+from nvsubquadratic.modules.hyena_nd import Hyena
+from nvsubquadratic.modules.kernels_nd import SIRENKernelND
+from nvsubquadratic.modules.masks_nd import GaussianModulationND
+from nvsubquadratic.modules.mlp import MLP
+from nvsubquadratic.modules.rms_norm import RMSNorm
+from nvsubquadratic.modules.sequence_mixer import QKVSequenceMixer
+from nvsubquadratic.modules.vit5_attention import ViT5Attention
+from nvsubquadratic.modules.vit5_hyena_adapter import ViT5HyenaAdapter
+from nvsubquadratic.modules.vit5_residual_block import ViT5ResidualBlock
+from nvsubquadratic.networks.vit5_classification import ViT5ClassificationNet
+from nvsubquadratic.utils.init import trunc_normal_init, trunc_normal_init_factory
+from nvsubquadratic.utils.qk_norm import L2Norm
+
+
+# Re-export for convenience in leaf configs
+__all__ = ["build_hybrid_net", "get_base_config"]
+
+
+# ─── Initialization (uniform trunc_normal for all layers) ────────────────────
+INIT_FN = trunc_normal_init(std=0.02)
+INIT_FN_FACTORY = trunc_normal_init_factory(std=0.02)
+
+# ─── Attention constants ─────────────────────────────────────────────────────
+NUM_HEADS = 6
+HEAD_DIM = HIDDEN_DIM // NUM_HEADS  # 64
+NUM_REGISTERS = 4
+DROP_PATH_RATE = 0.05
+
+# ─── SIREN kernel hyperparameters ────────────────────────────────────────────
+KERNEL_MLP_HIDDEN_DIM = 32
+KERNEL_NUM_LAYERS = 3
+KERNEL_EMBEDDING_DIM = 32
+KERNEL_OMEGA_0 = 10.0
+KERNEL_HIDDEN_OMEGA_0 = 1.0
+
+
+# ─── Interpolation expressions ──────────────────────────────────────────────
+# These use the ${eval:'...'} OmegaConf resolver registered in cli.py.
+# Inner ${net.xxx} references are resolved first, then the arithmetic is evaluated.
+_NUM_PATCHES_W = "${eval:'${net.image_size} // ${net.patch_size}'}"
+_NUM_NON_PAD = "${eval:'(${net.image_size} // ${net.patch_size}) ** 2 + 1 + ${net.num_registers}'}"
+_PAD_SIZE = "${eval:'(-(${net.image_size} // ${net.patch_size}) ** 2 - 1 - ${net.num_registers}) % (${net.image_size} // ${net.patch_size})'}"
+_GRID_H = "${eval:'((${net.image_size} // ${net.patch_size}) ** 2 + 1 + ${net.num_registers} + (-(${net.image_size} // ${net.patch_size}) ** 2 - 1 - ${net.num_registers}) % (${net.image_size} // ${net.patch_size})) // (${net.image_size} // ${net.patch_size})'}"
+
+
+# ─── Block builders ──────────────────────────────────────────────────────────
+
+
+def _make_attention_block_cfg() -> LazyConfig:
+    """Build a ViT5ResidualBlock config with standard attention.
+
+    All dimension and grid values use ``${eval:'...'}"`` interpolation so they
+    stay in sync with the top-level network config.
+    """
+    return LazyConfig(ViT5ResidualBlock)(
+        sequence_mixer_cfg=LazyConfig(ViT5Attention)(
+            hidden_dim="${net.hidden_dim}",
+            num_heads=NUM_HEADS,
+            num_patches_h=_NUM_PATCHES_W,
+            num_patches_w=_NUM_PATCHES_W,
+            num_registers="${net.num_registers}",
+            qk_norm=LazyConfig(RMSNorm)(
+                dim="${eval:'${net.hidden_dim} // ${net.layer_types.A.sequence_mixer_cfg.num_heads}'}", eps=1e-6
+            ),
+            rope_base=10000.0,
+            reg_rope_base=100.0,
+            attn_dropout=0.0,
+            proj_dropout=0.0,
+            qkv_bias=False,
+            out_proj_bias=False,
+            init_fn_qkv_proj=INIT_FN,
+            init_fn_out_proj=INIT_FN,
+        ),
+        sequence_mixer_norm_cfg=LazyConfig(RMSNorm)(dim="${net.hidden_dim}", eps=1e-6),
+        mlp_cfg=LazyConfig(MLP)(
+            dim="${net.hidden_dim}",
+            activation="gelu",
+            expansion_factor=float(MLP_RATIO),
+            bias=False,
+            dropout_cfg=LazyConfig(torch.nn.Dropout)(p=0.0),
+            init_method_in=INIT_FN_FACTORY,
+            init_method_out=INIT_FN_FACTORY,
+        ),
+        mlp_norm_cfg=LazyConfig(RMSNorm)(dim="${net.hidden_dim}", eps=1e-6),
+        hidden_dim="${net.hidden_dim}",
+        layer_scale_init=LAYER_SCALE_INIT,
+    )
+
+
+def _make_hyena_block_cfg() -> LazyConfig:
+    """Build a ViT5ResidualBlock config with Hyena + GRN (no FiLM).
+
+    All dimension and grid values use ``${eval:'...'}"`` interpolation so they
+    stay in sync with the top-level network config.
+    """
+    mixer_cfg = LazyConfig(QKVSequenceMixer)(
+        hidden_dim="${net.hidden_dim}",
+        mixer_cfg=LazyConfig(Hyena)(
+            global_conv_cfg=LazyConfig(CKConvND)(
+                data_dim=2,
+                hidden_dim="${net.hidden_dim}",
+                kernel_cfg=LazyConfig(SIRENKernelND)(
+                    data_dim=2,
+                    out_dim="${net.hidden_dim}",
+                    mlp_hidden_dim=KERNEL_MLP_HIDDEN_DIM,
+                    num_layers=KERNEL_NUM_LAYERS,
+                    embedding_dim=KERNEL_EMBEDDING_DIM,
+                    omega_0=KERNEL_OMEGA_0,
+                    L_cache=_GRID_H,
+                    use_bias=True,
+                    hidden_omega_0=KERNEL_HIDDEN_OMEGA_0,
+                ),
+                mask_cfg=LazyConfig(GaussianModulationND)(
+                    data_dim=2,
+                    num_channels="${net.hidden_dim}",
+                    min_attenuation_at_step=0.1,
+                    max_attenuation_at_limit=0.95,
+                    init_extent=1.0,
+                    parametrization="direct",
+                ),
+                grid_type="double",
+                fft_padding="zero",
+                fft_backend="subq_ops",
+            ),
+            short_conv_cfg=LazyConfig(torch.nn.Conv2d)(
+                in_channels="${eval:'3 * ${net.hidden_dim}'}",
+                out_channels="${eval:'3 * ${net.hidden_dim}'}",
+                kernel_size=3,
+                groups="${eval:'3 * ${net.hidden_dim}'}",
+                padding=1,
+                bias=False,
+            ),
+            gate_nonlinear_cfg=LazyConfig(torch.nn.SiLU)(),
+            pixelhyena_norm_cfg=LazyConfig(RMSNorm)(dim="${net.hidden_dim}", eps=1e-6),
+            qk_norm_cfg=LazyConfig(L2Norm)(),
+            use_rope=False,
+            output_norm_cfg=LazyConfig(RMSNorm)(dim="${net.hidden_dim}", eps=1e-6),
+            gate_nonlinear_2_cfg=LazyConfig(torch.nn.Sigmoid)(),
+        ),
+        qkv_bias=False,
+        out_proj_bias=False,
+        init_method_in=INIT_FN_FACTORY,
+        init_method_out=INIT_FN_FACTORY,
+    )
+
+    return LazyConfig(ViT5ResidualBlock)(
+        sequence_mixer_cfg=LazyConfig(ViT5HyenaAdapter)(
+            inner_mixer_cfg=mixer_cfg,
+            grid_w=_NUM_PATCHES_W,
+        ),
+        sequence_mixer_norm_cfg=LazyConfig(RMSNorm)(dim="${net.hidden_dim}", eps=1e-6),
+        mlp_cfg=LazyConfig(MLP)(
+            dim="${net.hidden_dim}",
+            activation="gelu",
+            expansion_factor=float(MLP_RATIO),
+            bias=False,
+            dropout_cfg=LazyConfig(torch.nn.Dropout)(p=0.0),
+            init_method_in=INIT_FN_FACTORY,
+            init_method_out=INIT_FN_FACTORY,
+        ),
+        mlp_norm_cfg=LazyConfig(RMSNorm)(dim="${net.hidden_dim}", eps=1e-6),
+        hidden_dim="${net.hidden_dim}",
+        layer_scale_init=LAYER_SCALE_INIT,
+        grn_cfg=LazyConfig(GlobalResponseNorm)(dim="${net.hidden_dim}"),
+    )
+
+
+# ─── Network builder ─────────────────────────────────────────────────────────
+
+
+def build_hybrid_net(
+    layer_pattern: str = "HA" * (NUM_BLOCKS // 2),
+    patch_size: int = PATCH_SIZE,
+    max_drop_path_rate: float = DROP_PATH_RATE,
+    drop_path_schedule: str = "constant",
+) -> LazyConfig:
+    """Build ViT5ClassificationNet with interleaved Hyena/Attention blocks.
+
+    Args:
+        layer_pattern: Pattern string where ``"H"`` = Hyena block,
+            ``"A"`` = Attention block.  Default ``"HA" * 6`` (12 blocks).
+        patch_size: Patch size for the embedding layer (default 16).
+            All grid / padding math is derived via
+            ``"${eval:'${net.image_size} // ${net.patch_size}'}"``
+            interpolation in the nested block configs.
+        max_drop_path_rate: Maximum stochastic depth rate.
+        drop_path_schedule: ``"constant"`` or ``"linear"`` ramp.
+
+    Returns:
+        LazyConfig for ViT5ClassificationNet.
+    """
+    num_blocks = len(layer_pattern)
+
+    layer_types = {}
+    if "A" in layer_pattern:
+        layer_types["A"] = _make_attention_block_cfg()
+    if "H" in layer_pattern:
+        layer_types["H"] = _make_hyena_block_cfg()
+
+    return LazyConfig(ViT5ClassificationNet)(
+        in_channels=INPUT_CHANNELS,
+        num_classes=NUM_CLASSES,
+        hidden_dim=HIDDEN_DIM,
+        num_blocks=num_blocks,
+        patch_size=patch_size,
+        image_size=FINAL_IMAGE_SIZE,
+        num_registers=NUM_REGISTERS,
+        dropout_rate=0.0,
+        readout="cls",
+        norm_cfg=LazyConfig(RMSNorm)(dim="${net.hidden_dim}", eps=1e-6),
+        layer_pattern=layer_pattern,
+        layer_types=layer_types,
+        max_drop_path_rate=max_drop_path_rate,
+        drop_path_schedule=drop_path_schedule,
+    )

--- a/examples/vit5_imagenet/vit5_hybrid/full_attention.py
+++ b/examples/vit5_imagenet/vit5_hybrid/full_attention.py
@@ -1,0 +1,21 @@
+"""Full Attention – 12 attention blocks.
+
+Layout: A A A A A A A A A A A A
+
+Override ``net.patch_size`` to change resolution (default 16).
+"""
+
+from examples.vit5_imagenet.v5._base import NUM_BLOCKS, PATCH_SIZE
+from examples.vit5_imagenet.vit5_hybrid._base_config import (
+    build_hybrid_net,
+    get_base_config,
+)
+
+
+LAYER_PATTERN = "A" * NUM_BLOCKS
+
+config = get_base_config()
+config.compile = True
+config.compile_mode = "max-autotune-no-cudagraphs"
+config.net = build_hybrid_net(layer_pattern=LAYER_PATTERN, patch_size=PATCH_SIZE)
+config.wandb.job_group = "vit5_hybrid"

--- a/examples/vit5_imagenet/vit5_hybrid/full_attention.py
+++ b/examples/vit5_imagenet/vit5_hybrid/full_attention.py
@@ -17,6 +17,7 @@ LAYER_PATTERN = "A" * NUM_BLOCKS
 
 
 def get_config() -> ExperimentConfig:
+    """Return the full-attention (12 A) hybrid config."""
     config = get_base_config()
     config.compile = True
     config.compile_mode = "max-autotune-no-cudagraphs"

--- a/examples/vit5_imagenet/vit5_hybrid/full_attention.py
+++ b/examples/vit5_imagenet/vit5_hybrid/full_attention.py
@@ -10,12 +10,16 @@ from examples.vit5_imagenet.vit5_hybrid._base_config import (
     build_hybrid_net,
     get_base_config,
 )
+from experiments.default_cfg import ExperimentConfig
 
 
 LAYER_PATTERN = "A" * NUM_BLOCKS
 
-config = get_base_config()
-config.compile = True
-config.compile_mode = "max-autotune-no-cudagraphs"
-config.net = build_hybrid_net(layer_pattern=LAYER_PATTERN, patch_size=PATCH_SIZE)
-config.wandb.job_group = "vit5_hybrid"
+
+def get_config() -> ExperimentConfig:
+    config = get_base_config()
+    config.compile = True
+    config.compile_mode = "max-autotune-no-cudagraphs"
+    config.net = build_hybrid_net(layer_pattern=LAYER_PATTERN, patch_size=PATCH_SIZE)
+    config.wandb.job_group = "vit5_hybrid"
+    return config

--- a/examples/vit5_imagenet/vit5_hybrid/full_hyena.py
+++ b/examples/vit5_imagenet/vit5_hybrid/full_hyena.py
@@ -1,0 +1,21 @@
+"""Full Hyena – 12 Hyena blocks.
+
+Layout: H H H H H H H H H H H H
+
+Override ``net.patch_size`` to change resolution (default 16).
+"""
+
+from examples.vit5_imagenet.v5._base import NUM_BLOCKS, PATCH_SIZE
+from examples.vit5_imagenet.vit5_hybrid._base_config import (
+    build_hybrid_net,
+    get_base_config,
+)
+
+
+LAYER_PATTERN = "H" * NUM_BLOCKS
+
+config = get_base_config()
+config.compile = True
+config.compile_mode = "max-autotune-no-cudagraphs"
+config.net = build_hybrid_net(layer_pattern=LAYER_PATTERN, patch_size=PATCH_SIZE)
+config.wandb.job_group = "vit5_hybrid"

--- a/examples/vit5_imagenet/vit5_hybrid/full_hyena.py
+++ b/examples/vit5_imagenet/vit5_hybrid/full_hyena.py
@@ -10,12 +10,16 @@ from examples.vit5_imagenet.vit5_hybrid._base_config import (
     build_hybrid_net,
     get_base_config,
 )
+from experiments.default_cfg import ExperimentConfig
 
 
 LAYER_PATTERN = "H" * NUM_BLOCKS
 
-config = get_base_config()
-config.compile = True
-config.compile_mode = "max-autotune-no-cudagraphs"
-config.net = build_hybrid_net(layer_pattern=LAYER_PATTERN, patch_size=PATCH_SIZE)
-config.wandb.job_group = "vit5_hybrid"
+
+def get_config() -> ExperimentConfig:
+    config = get_base_config()
+    config.compile = True
+    config.compile_mode = "max-autotune-no-cudagraphs"
+    config.net = build_hybrid_net(layer_pattern=LAYER_PATTERN, patch_size=PATCH_SIZE)
+    config.wandb.job_group = "vit5_hybrid"
+    return config

--- a/examples/vit5_imagenet/vit5_hybrid/full_hyena.py
+++ b/examples/vit5_imagenet/vit5_hybrid/full_hyena.py
@@ -17,6 +17,7 @@ LAYER_PATTERN = "H" * NUM_BLOCKS
 
 
 def get_config() -> ExperimentConfig:
+    """Return the full-Hyena (12 H) hybrid config."""
     config = get_base_config()
     config.compile = True
     config.compile_mode = "max-autotune-no-cudagraphs"

--- a/examples/vit5_imagenet/vit5_hybrid/hybrid_ha.py
+++ b/examples/vit5_imagenet/vit5_hybrid/hybrid_ha.py
@@ -18,6 +18,7 @@ LAYER_PATTERN = "HA" * (NUM_BLOCKS // 2)
 
 
 def get_config() -> ExperimentConfig:
+    """Return the alternating HA hybrid config."""
     config = get_base_config()
     config.compile = True
     config.compile_mode = "max-autotune-no-cudagraphs"

--- a/examples/vit5_imagenet/vit5_hybrid/hybrid_ha.py
+++ b/examples/vit5_imagenet/vit5_hybrid/hybrid_ha.py
@@ -1,0 +1,22 @@
+"""Hybrid Hyena/Attention – alternating HA pattern (12 blocks).
+
+Layout: H A H A H A H A H A H A
+         └─────── 6 pairs ─────┘
+
+Override ``net.patch_size`` to change resolution (default 16).
+"""
+
+from examples.vit5_imagenet.v5._base import NUM_BLOCKS, PATCH_SIZE
+from examples.vit5_imagenet.vit5_hybrid._base_config import (
+    build_hybrid_net,
+    get_base_config,
+)
+
+
+LAYER_PATTERN = "HA" * (NUM_BLOCKS // 2)
+
+config = get_base_config()
+config.compile = True
+config.compile_mode = "max-autotune-no-cudagraphs"
+config.net = build_hybrid_net(layer_pattern=LAYER_PATTERN, patch_size=PATCH_SIZE)
+config.wandb.job_group = "vit5_hybrid"

--- a/examples/vit5_imagenet/vit5_hybrid/hybrid_ha.py
+++ b/examples/vit5_imagenet/vit5_hybrid/hybrid_ha.py
@@ -11,12 +11,16 @@ from examples.vit5_imagenet.vit5_hybrid._base_config import (
     build_hybrid_net,
     get_base_config,
 )
+from experiments.default_cfg import ExperimentConfig
 
 
 LAYER_PATTERN = "HA" * (NUM_BLOCKS // 2)
 
-config = get_base_config()
-config.compile = True
-config.compile_mode = "max-autotune-no-cudagraphs"
-config.net = build_hybrid_net(layer_pattern=LAYER_PATTERN, patch_size=PATCH_SIZE)
-config.wandb.job_group = "vit5_hybrid"
+
+def get_config() -> ExperimentConfig:
+    config = get_base_config()
+    config.compile = True
+    config.compile_mode = "max-autotune-no-cudagraphs"
+    config.net = build_hybrid_net(layer_pattern=LAYER_PATTERN, patch_size=PATCH_SIZE)
+    config.wandb.job_group = "vit5_hybrid"
+    return config

--- a/examples/vit5_imagenet/vit5_hybrid/hybrid_hhha.py
+++ b/examples/vit5_imagenet/vit5_hybrid/hybrid_hhha.py
@@ -11,12 +11,16 @@ from examples.vit5_imagenet.vit5_hybrid._base_config import (
     build_hybrid_net,
     get_base_config,
 )
+from experiments.default_cfg import ExperimentConfig
 
 
 LAYER_PATTERN = "HHHA" * (NUM_BLOCKS // 4)
 
-config = get_base_config()
-config.compile = True
-config.compile_mode = "max-autotune-no-cudagraphs"
-config.net = build_hybrid_net(layer_pattern=LAYER_PATTERN, patch_size=PATCH_SIZE)
-config.wandb.job_group = "vit5_hybrid"
+
+def get_config() -> ExperimentConfig:
+    config = get_base_config()
+    config.compile = True
+    config.compile_mode = "max-autotune-no-cudagraphs"
+    config.net = build_hybrid_net(layer_pattern=LAYER_PATTERN, patch_size=PATCH_SIZE)
+    config.wandb.job_group = "vit5_hybrid"
+    return config

--- a/examples/vit5_imagenet/vit5_hybrid/hybrid_hhha.py
+++ b/examples/vit5_imagenet/vit5_hybrid/hybrid_hhha.py
@@ -18,6 +18,7 @@ LAYER_PATTERN = "HHHA" * (NUM_BLOCKS // 4)
 
 
 def get_config() -> ExperimentConfig:
+    """Return the 3:1 Hyena/Attention (HHHA) hybrid config."""
     config = get_base_config()
     config.compile = True
     config.compile_mode = "max-autotune-no-cudagraphs"

--- a/examples/vit5_imagenet/vit5_hybrid/hybrid_hhha.py
+++ b/examples/vit5_imagenet/vit5_hybrid/hybrid_hhha.py
@@ -1,0 +1,22 @@
+"""Hybrid Hyena/Attention – 3:1 Hyena-to-Attention ratio (12 blocks).
+
+Layout: H H H A H H H A H H H A
+         └─────── 3 groups ─────┘
+
+Override ``net.patch_size`` to change resolution (default 16).
+"""
+
+from examples.vit5_imagenet.v5._base import NUM_BLOCKS, PATCH_SIZE
+from examples.vit5_imagenet.vit5_hybrid._base_config import (
+    build_hybrid_net,
+    get_base_config,
+)
+
+
+LAYER_PATTERN = "HHHA" * (NUM_BLOCKS // 4)
+
+config = get_base_config()
+config.compile = True
+config.compile_mode = "max-autotune-no-cudagraphs"
+config.net = build_hybrid_net(layer_pattern=LAYER_PATTERN, patch_size=PATCH_SIZE)
+config.wandb.job_group = "vit5_hybrid"

--- a/examples/vit5_imagenet/vit5_hybrid/plan.md
+++ b/examples/vit5_imagenet/vit5_hybrid/plan.md
@@ -6,7 +6,7 @@ Session ID: `vit5_hybrid`
 
 We need to launch 8 training experiments (4 hybrid configs x 2 patch sizes) from the TRACKER at `examples/vit5_imagenet/vit5_hybrid/TRACKER.md`. The key requirement is using a **new container image** (`nvsubquadratic-slurm-x86_64-04-17-2026.sqsh`) instead of the old one baked into the existing slurm scripts. The existing configs and training infrastructure are already correct — we only need a new submit script and a bug fix.
 
----
+______________________________________________________________________
 
 ## Files Created/Modified
 
@@ -14,14 +14,14 @@ We need to launch 8 training experiments (4 hybrid configs x 2 patch sizes) from
 
 Based on `slurm/submit_in1k_cls.sh` with these changes:
 
-| What | Old value | New value |
-|------|-----------|-----------|
+| What                    | Old value                                             | New value                                                                  |
+| ----------------------- | ----------------------------------------------------- | -------------------------------------------------------------------------- |
 | Container image default | `.../farhadr/enroot/nvsubquadratic-slurm-x86_64.sqsh` | `.../amoradzadeh/hyena/enroot/nvsubquadratic-slurm-x86_64-04-17-2026.sqsh` |
-| ImageNet paths | `${CONTAINER_DATA}/imagenet` | `${CONTAINER_DATA}/imagenet_folder` |
-| Job name | `nvsubq.v5patch` | `nvsubq.v5hybrid` |
-| Usage comments | References v5_patch configs | References vit5_hybrid configs |
-| `PYTHON_CMD` block | No HF/W&B cache dirs | Add `HF_HOME`, `WANDB_DIR`, etc. env vars |
-| Config overrides | No compile_mode | Add `compile_mode=max-autotune-no-cudagraphs` |
+| ImageNet paths          | `${CONTAINER_DATA}/imagenet`                          | `${CONTAINER_DATA}/imagenet_folder`                                        |
+| Job name                | `nvsubq.v5patch`                                      | `nvsubq.v5hybrid`                                                          |
+| Usage comments          | References v5_patch configs                           | References vit5_hybrid configs                                             |
+| `PYTHON_CMD` block      | No HF/W&B cache dirs                                  | Add `HF_HOME`, `WANDB_DIR`, etc. env vars                                  |
+| Config overrides        | No compile_mode                                       | Add `compile_mode=max-autotune-no-cudagraphs`                              |
 
 **Security**: Uses `export WANDB_API_KEY="${WANDB_API_KEY:-}"` (safe fallback). No hardcoded secrets.
 
@@ -37,7 +37,7 @@ sbatch ${dep_flag} "${SBATCH_EXTRA_ARGS[@]+"${SBATCH_EXTRA_ARGS[@]}"}" "${SCRIPT
 sbatch ${dep_flag} "${SCRIPT_NAME}" "${CONFIG}" "${SBATCH_EXTRA_ARGS[@]+"${SBATCH_EXTRA_ARGS[@]}"}"
 ```
 
----
+______________________________________________________________________
 
 ## No Changes Needed
 
@@ -45,7 +45,7 @@ sbatch ${dep_flag} "${SCRIPT_NAME}" "${CONFIG}" "${SBATCH_EXTRA_ARGS[@]+"${SBATC
 - **TRACKER.md** — already has the right tables; results filled in after runs complete
 - **`_base_config.py`** — `build_hybrid_net()` already handles `patch_size` via OmegaConf interpolation
 
----
+______________________________________________________________________
 
 ## Launch Commands
 
@@ -69,30 +69,179 @@ bash slurm/queue.sh slurm/submit_hybrid.sh 20 examples/vit5_imagenet/vit5_hybrid
 
 **Job chain count**: Patch-16 FLOPs ~9-10 GFLOPs -> 12 jobs is sufficient. Patch-8 FLOPs ~38-45 GFLOPs with 4x grad accum -> 20 jobs. Extra jobs are harmless (autoresume exits immediately if training is complete).
 
----
+______________________________________________________________________
 
 ## Risk: Container may not have hybrid code
 
 The code is baked into the container at `/workspaces/nvSubquadratic-private`. The new sqsh was built on 04-17-2026 — we need to verify it includes the `vit5_hybrid` configs (which are on the `dwromero/hybrid-vit5` branch). If it doesn't, training will fail at import time.
 
 **Workaround**: Mount the local repo into the container by adding to the mounts in `submit_hybrid.sh`:
+
 ```
 ${WORKDIR}:/workspaces/nvSubquadratic-private
 ```
 
----
+______________________________________________________________________
 
 ## Test Job
 
 Single patch-8 test job submitted as validation before full launch:
+
 ```bash
 sbatch slurm/submit_hybrid.sh examples/vit5_imagenet/vit5_hybrid/full_attention.py \
     net.patch_size=8 dataset.batch_size=64 train.accumulate_grad_steps=4
 ```
 
+## First Window Results (Patch 16 & 8)
+
+Completed first 4h window for all 8 experiments. Steady-state throughput:
+
+| Experiment     | Patch | Epochs in 4h | it/s  | imgs/s |
+| -------------- | ----- | ------------ | ----- | ------ |
+| full_attention | 8     | 85           | 16.45 | 1,053  |
+| full_attention | 16    | 285          | 13.86 | 3,548  |
+| hybrid_ha      | 8     | 55           | 11.08 | 709    |
+| hybrid_ha      | 16    | 173          | 8.63  | 2,209  |
+| hybrid_hhha    | 8     | 48           | 10.13 | 648    |
+| hybrid_hhha    | 16    | 150          | 7.64  | 1,956  |
+| full_hyena     | 8     | 45           | 9.35  | 599    |
+| full_hyena     | 16    | 134          | 6.99  | 1,789  |
+
+Note: it/s not directly comparable across patch sizes (batch/GPU differs: 256 for p16, 64 for p8).
+
+______________________________________________________________________
+
+## Phase 2: Patch 4, 2, 1 (4-node / 32 GPU)
+
+Created `slurm/submit_hybrid_4node.sh` — identical to `submit_hybrid.sh` but with `--nodes=4`.
+
+Batch config (4 nodes = 32 GPUs, effective batch = 2048):
+
+| Patch | batch/GPU | accum_steps | tokens/img |
+| ----- | --------- | ----------- | ---------- |
+| 4     | 16        | 4           | 3,141      |
+| 2     | 4         | 16          | 12,549     |
+| 1     | 1         | 64          | 50,181     |
+
+### Launch Commands (single test jobs)
+
+```bash
+# Patch 4
+sbatch slurm/submit_hybrid_4node.sh examples/vit5_imagenet/vit5_hybrid/full_attention.py net.patch_size=4 dataset.batch_size=16 train.accumulate_grad_steps=4
+sbatch slurm/submit_hybrid_4node.sh examples/vit5_imagenet/vit5_hybrid/hybrid_ha.py net.patch_size=4 dataset.batch_size=16 train.accumulate_grad_steps=4
+sbatch slurm/submit_hybrid_4node.sh examples/vit5_imagenet/vit5_hybrid/hybrid_hhha.py net.patch_size=4 dataset.batch_size=16 train.accumulate_grad_steps=4
+sbatch slurm/submit_hybrid_4node.sh examples/vit5_imagenet/vit5_hybrid/full_hyena.py net.patch_size=4 dataset.batch_size=16 train.accumulate_grad_steps=4
+
+# Patch 2
+sbatch slurm/submit_hybrid_4node.sh examples/vit5_imagenet/vit5_hybrid/full_attention.py net.patch_size=2 dataset.batch_size=4 train.accumulate_grad_steps=16
+sbatch slurm/submit_hybrid_4node.sh examples/vit5_imagenet/vit5_hybrid/hybrid_ha.py net.patch_size=2 dataset.batch_size=4 train.accumulate_grad_steps=16
+sbatch slurm/submit_hybrid_4node.sh examples/vit5_imagenet/vit5_hybrid/hybrid_hhha.py net.patch_size=2 dataset.batch_size=4 train.accumulate_grad_steps=16
+sbatch slurm/submit_hybrid_4node.sh examples/vit5_imagenet/vit5_hybrid/full_hyena.py net.patch_size=2 dataset.batch_size=4 train.accumulate_grad_steps=16
+
+# Patch 1
+sbatch slurm/submit_hybrid_4node.sh examples/vit5_imagenet/vit5_hybrid/full_attention.py net.patch_size=1 dataset.batch_size=1 train.accumulate_grad_steps=64
+sbatch slurm/submit_hybrid_4node.sh examples/vit5_imagenet/vit5_hybrid/hybrid_ha.py net.patch_size=1 dataset.batch_size=1 train.accumulate_grad_steps=64
+sbatch slurm/submit_hybrid_4node.sh examples/vit5_imagenet/vit5_hybrid/hybrid_hhha.py net.patch_size=1 dataset.batch_size=1 train.accumulate_grad_steps=64
+sbatch slurm/submit_hybrid_4node.sh examples/vit5_imagenet/vit5_hybrid/full_hyena.py net.patch_size=1 dataset.batch_size=1 train.accumulate_grad_steps=64
+```
+
+### Account Assignment
+
+- Patch 16/8 chain jobs (second wave): `healthcareeng_bionemo`
+- Patch 4/2/1 test jobs: `healthcareeng_research`
+
+______________________________________________________________________
+
+## Final Results — Patch 8 & 16 (800 epochs)
+
+All 7 priority experiments completed. Full_hyena p16 stopped at 799 but is treated as final (val_acc_ema stable).
+
+| Experiment     | Patch 16       | Patch 8   |
+| -------------- | -------------- | --------- |
+| full_attention | 0.817          | **0.835** |
+| hybrid_ha      | **0.819**      | 0.829     |
+| hybrid_hhha    | 0.815          | 0.826     |
+| full_hyena     | 0.813 (ep 799) | 0.825     |
+
+**Key takeaways:**
+
+- Hybrid architectures match/beat pure attention at p16 (hybrid_ha = 0.819 vs full_attn = 0.817).
+- Patch 8 gives ~2% absolute accuracy boost across all variants.
+- Within p16, all 4 variants within 0.6%. Within p8, all 4 within 1.0%.
+- Throughput crossover: Hyena > Attention between patch 4 and patch 2 (~3K–12K tokens).
+
+______________________________________________________________________
+
+## Phase 3: KERNEL_OMEGA_0 Ablation (Patch 8, 4 nodes)
+
+Ablation study launched 2026-04-21 to test whether a higher SIREN-kernel base frequency improves Hyena-containing configs at patch 8.
+
+**Base value**: `KERNEL_OMEGA_0 = 10.0` (set in `_base_config.py:69`)
+**Ablation value**: `KERNEL_OMEGA_0 = 20.0` (patch-8)
+
+### Approach: CLI override (zero code changes)
+
+Override path (verified via smoke test):
+
+```
+net.layer_types.H.sequence_mixer_cfg.inner_mixer_cfg.mixer_cfg.global_conv_cfg.kernel_cfg.omega_0=20.0
+```
+
+Existing configs (`full_hyena.py`, `hybrid_hhha.py`, `hybrid_ha.py`) are unmodified. Different CLI overrides produce different run-hashes, so results land in separate `run_<hash>/` dirs — no collision with original omega=10 runs.
+
+### Configuration
+
+- **Scope**: Only Hyena-containing configs (`full_hyena`, `hybrid_hhha`, `hybrid_ha`). `full_attention` has no H block and is skipped.
+- **Hardware**: 4 nodes × 8 GPUs = 32 GPUs.
+- **Batch config**: `dataset.batch_size=64 train.accumulate_grad_steps=1` → effective batch = 32 × 64 × 1 = **2048** (matches original).
+- **Iters/epoch**: ~626 (vs 2502 for 1-node runs). Each iter does 4× more work, net wall-clock per epoch similar or faster.
+- **Expected epochs/window**: ~150–200 epochs per 4h window → **~5 chain jobs to reach 800**.
+
+### Launch Commands
+
+```bash
+OMEGA_OVR='net.layer_types.H.sequence_mixer_cfg.inner_mixer_cfg.mixer_cfg.global_conv_cfg.kernel_cfg.omega_0=20.0'
+
+# full_hyena p8 omega=20.0
+bash slurm/queue.sh slurm/submit_hybrid_4node.sh 7 \
+    examples/vit5_imagenet/vit5_hybrid/full_hyena.py \
+    net.patch_size=8 dataset.batch_size=64 train.accumulate_grad_steps=1 $OMEGA_OVR
+
+# hybrid_hhha p8 omega=20.0
+bash slurm/queue.sh slurm/submit_hybrid_4node.sh 7 \
+    examples/vit5_imagenet/vit5_hybrid/hybrid_hhha.py \
+    net.patch_size=8 dataset.batch_size=64 train.accumulate_grad_steps=1 $OMEGA_OVR
+
+# hybrid_ha p8 omega=20.0
+bash slurm/queue.sh slurm/submit_hybrid_4node.sh 7 \
+    examples/vit5_imagenet/vit5_hybrid/hybrid_ha.py \
+    net.patch_size=8 dataset.batch_size=64 train.accumulate_grad_steps=1 $OMEGA_OVR
+```
+
+### Baseline for comparison
+
+| Config (p8, omega=10) | val/acc_ema | Patch-8 omega=20.0 |
+| --------------------- | ----------- | ------------------ |
+| full_hyena            | 0.825       | TBD                |
+| hybrid_hhha           | 0.826       | TBD                |
+| hybrid_ha             | 0.829       | TBD                |
+
+______________________________________________________________________
+
+## Notes on Pending / Future Ablations
+
+- **Patch 4 original (omega=10.0) runs**: in progress from Phase 2.
+- **Patch 2 / Patch 1**: only throughput-benchmark runs so far (patch 1 preempted on backfill partition due to very long epochs).
+
+______________________________________________________________________
+
 ## Verification Checklist
 
-1. Submit a single patch-8 job, verify no OOM and correct batch config
-2. Submit a single patch-16 job, check slurm output for successful training start
-3. Check W&B for the run appearing under `vit5_hybrid` job group
-4. If both pass, launch the full set of 8 chained experiments
+1. ~~Submit a single patch-8 job, verify no OOM and correct batch config~~ DONE
+1. ~~Submit a single patch-16 job, check slurm output for successful training start~~ DONE
+1. ~~Check W&B for the run appearing under `vit5_hybrid` job group~~ DONE
+1. ~~If both pass, launch the full set of 8 chained experiments~~ DONE
+1. ~~Monitor patch 4/2/1 test jobs for OOM~~ DONE (patch 1 preempted, not retried)
+1. ~~Chain full 800-epoch p8/p16 runs~~ DONE (7/8 complete; full_hyena p16 at ep 799)
+1. ~~Verify omega_0 CLI override resolves correctly~~ DONE (smoke test 2026-04-21)
+1. Run omega=20.0 ablation for hyena-containing p8 configs and compare to omega=10 baselines

--- a/examples/vit5_imagenet/vit5_hybrid/plan.md
+++ b/examples/vit5_imagenet/vit5_hybrid/plan.md
@@ -1,0 +1,98 @@
+# Plan: vit5_hybrid Experiment Launch Infrastructure
+
+Session ID: `vit5_hybrid`
+
+## Context
+
+We need to launch 8 training experiments (4 hybrid configs x 2 patch sizes) from the TRACKER at `examples/vit5_imagenet/vit5_hybrid/TRACKER.md`. The key requirement is using a **new container image** (`nvsubquadratic-slurm-x86_64-04-17-2026.sqsh`) instead of the old one baked into the existing slurm scripts. The existing configs and training infrastructure are already correct — we only need a new submit script and a bug fix.
+
+---
+
+## Files Created/Modified
+
+### 1. Created `slurm/submit_hybrid.sh` (new file)
+
+Based on `slurm/submit_in1k_cls.sh` with these changes:
+
+| What | Old value | New value |
+|------|-----------|-----------|
+| Container image default | `.../farhadr/enroot/nvsubquadratic-slurm-x86_64.sqsh` | `.../amoradzadeh/hyena/enroot/nvsubquadratic-slurm-x86_64-04-17-2026.sqsh` |
+| ImageNet paths | `${CONTAINER_DATA}/imagenet` | `${CONTAINER_DATA}/imagenet_folder` |
+| Job name | `nvsubq.v5patch` | `nvsubq.v5hybrid` |
+| Usage comments | References v5_patch configs | References vit5_hybrid configs |
+| `PYTHON_CMD` block | No HF/W&B cache dirs | Add `HF_HOME`, `WANDB_DIR`, etc. env vars |
+| Config overrides | No compile_mode | Add `compile_mode=max-autotune-no-cudagraphs` |
+
+**Security**: Uses `export WANDB_API_KEY="${WANDB_API_KEY:-}"` (safe fallback). No hardcoded secrets.
+
+### 2. Fixed `slurm/queue.sh` (line 45) — config override passthrough bug
+
+**Problem**: Extra args (like `net.patch_size=8`) were placed BEFORE the script name in the `sbatch` call, so sbatch tried to parse them as sbatch options and failed.
+
+```bash
+# Before (broken for config overrides):
+sbatch ${dep_flag} "${SBATCH_EXTRA_ARGS[@]+"${SBATCH_EXTRA_ARGS[@]}"}" "${SCRIPT_NAME}" "${CONFIG}"
+
+# After (overrides passed as script positional args):
+sbatch ${dep_flag} "${SCRIPT_NAME}" "${CONFIG}" "${SBATCH_EXTRA_ARGS[@]+"${SBATCH_EXTRA_ARGS[@]}"}"
+```
+
+---
+
+## No Changes Needed
+
+- **Config files** (`full_attention.py`, `hybrid_ha.py`, `hybrid_hhha.py`, `full_hyena.py`) — already correct
+- **TRACKER.md** — already has the right tables; results filled in after runs complete
+- **`_base_config.py`** — `build_hybrid_net()` already handles `patch_size` via OmegaConf interpolation
+
+---
+
+## Launch Commands
+
+From `/lustre/fsw/healthcareeng_bionemo/amoradzadeh/hyena/vit5_nvsubq/`:
+
+```bash
+# Patch 16 (default batch=256, no grad accum, ~12 chained 4h jobs)
+bash slurm/queue.sh slurm/submit_hybrid.sh 12 examples/vit5_imagenet/vit5_hybrid/full_attention.py
+bash slurm/queue.sh slurm/submit_hybrid.sh 12 examples/vit5_imagenet/vit5_hybrid/hybrid_ha.py
+bash slurm/queue.sh slurm/submit_hybrid.sh 12 examples/vit5_imagenet/vit5_hybrid/hybrid_hhha.py
+bash slurm/queue.sh slurm/submit_hybrid.sh 12 examples/vit5_imagenet/vit5_hybrid/full_hyena.py
+
+# Patch 8 (batch=64, accum=4 to maintain effective batch 2048, ~20 chained jobs)
+bash slurm/queue.sh slurm/submit_hybrid.sh 20 examples/vit5_imagenet/vit5_hybrid/full_attention.py net.patch_size=8 dataset.batch_size=64 train.accumulate_grad_steps=4
+bash slurm/queue.sh slurm/submit_hybrid.sh 20 examples/vit5_imagenet/vit5_hybrid/hybrid_ha.py net.patch_size=8 dataset.batch_size=64 train.accumulate_grad_steps=4
+bash slurm/queue.sh slurm/submit_hybrid.sh 20 examples/vit5_imagenet/vit5_hybrid/hybrid_hhha.py net.patch_size=8 dataset.batch_size=64 train.accumulate_grad_steps=4
+bash slurm/queue.sh slurm/submit_hybrid.sh 20 examples/vit5_imagenet/vit5_hybrid/full_hyena.py net.patch_size=8 dataset.batch_size=64 train.accumulate_grad_steps=4
+```
+
+**Batch size rationale for patch 8**: 784 tokens/image (vs 196 for patch 16). Default batch=256 will OOM on H100 80GB. The v5_patch experiments use batch=64 + accum=4 for patch 8, maintaining effective batch = 8 GPUs x 64 x 4 = 2048.
+
+**Job chain count**: Patch-16 FLOPs ~9-10 GFLOPs -> 12 jobs is sufficient. Patch-8 FLOPs ~38-45 GFLOPs with 4x grad accum -> 20 jobs. Extra jobs are harmless (autoresume exits immediately if training is complete).
+
+---
+
+## Risk: Container may not have hybrid code
+
+The code is baked into the container at `/workspaces/nvSubquadratic-private`. The new sqsh was built on 04-17-2026 — we need to verify it includes the `vit5_hybrid` configs (which are on the `dwromero/hybrid-vit5` branch). If it doesn't, training will fail at import time.
+
+**Workaround**: Mount the local repo into the container by adding to the mounts in `submit_hybrid.sh`:
+```
+${WORKDIR}:/workspaces/nvSubquadratic-private
+```
+
+---
+
+## Test Job
+
+Single patch-8 test job submitted as validation before full launch:
+```bash
+sbatch slurm/submit_hybrid.sh examples/vit5_imagenet/vit5_hybrid/full_attention.py \
+    net.patch_size=8 dataset.batch_size=64 train.accumulate_grad_steps=4
+```
+
+## Verification Checklist
+
+1. Submit a single patch-8 job, verify no OOM and correct batch config
+2. Submit a single patch-16 job, check slurm output for successful training start
+3. Check W&B for the run appearing under `vit5_hybrid` job group
+4. If both pass, launch the full set of 8 chained experiments

--- a/nvsubquadratic/modules/hyena_nd.py
+++ b/nvsubquadratic/modules/hyena_nd.py
@@ -138,10 +138,15 @@ class Hyena(torch.nn.Module):
         for param in self.output_norm.parameters():
             param._no_weight_decay = True
 
-        # QK Normalization (separate instances for Q and K to support stateful norms like RMSNorm)
+        # QK Normalization (separate instances for Q and K to support stateful norms like RMSNorm).
+        # K-norm is only useful when gating is linear (Identity); a nonlinear gate
+        # (e.g. SiLU) already bounds K's magnitude, so we use Identity for k_norm.
         if qk_norm_cfg is not None:
             self.q_norm = instantiate(qk_norm_cfg)
-            self.k_norm = instantiate(qk_norm_cfg)
+            if isinstance(self.gate_nonlinear, torch.nn.Identity):
+                self.k_norm = instantiate(qk_norm_cfg)
+            else:
+                self.k_norm = torch.nn.Identity()
         else:
             self.q_norm = None
             self.k_norm = None
@@ -158,8 +163,9 @@ class Hyena(torch.nn.Module):
     def extra_repr(self) -> str:
         """Return extra representation string for the module."""
         is_causal = getattr(self.global_conv, "is_causal", None)
-        qk_norm_str = self.q_norm.__class__.__name__ if self.q_norm is not None else "None"
-        parts = [f"qk_norm={qk_norm_str}", f"use_rope={self.use_rope}"]
+        q_norm_str = self.q_norm.__class__.__name__ if self.q_norm is not None else "None"
+        k_norm_str = self.k_norm.__class__.__name__ if self.k_norm is not None else "None"
+        parts = [f"q_norm={q_norm_str}", f"k_norm={k_norm_str}", f"use_rope={self.use_rope}"]
         if self.gate_nonlinear is not self.gate_nonlinear_2:
             g1 = self.gate_nonlinear.__class__.__name__
             g2 = self.gate_nonlinear_2.__class__.__name__
@@ -318,10 +324,10 @@ class Hyena(torch.nn.Module):
         if self.use_rope:
             flops += 4 * C * S
 
-        # 3. QK-Norm
+        # 3. QK-Norm (k_norm is Identity when gate is non-linear, so no extra FLOPs)
         if self.q_norm is not None:
             flops += 3 * C * S  # Q norm
-            if isinstance(self.gate_nonlinear, torch.nn.Identity):
+            if not isinstance(self.k_norm, torch.nn.Identity):
                 flops += 3 * C * S  # K norm (only for linear gating)
 
         # 4. First gate: Q * σ(K)
@@ -453,11 +459,11 @@ class Hyena(torch.nn.Module):
         # QK normalization (after RoPE).
         # Tensors are BHL: [B, C, *spatial]. Move C to last dim for norms that
         # expect channel-last (RMSNorm, LayerNorm, L2Norm with dim=-1).
-        # K is only normalized when gate_nonlinear is Identity (linear gating),
-        # because a nonlinear σ(K) already bounds the magnitude.
+        # k_norm is Identity when gate_nonlinear is non-linear (set in __init__);
+        # skip the movedim round-trip in that case to avoid overhead.
         if self.q_norm is not None:
             query = self.q_norm(query.movedim(1, -1)).movedim(-1, 1)
-            if isinstance(self.gate_nonlinear, torch.nn.Identity):
+            if not isinstance(self.k_norm, torch.nn.Identity):
                 key = self.k_norm(key.movedim(1, -1)).movedim(-1, 1)
 
         # First gate: z = Q ⊙ σ(K)

--- a/nvsubquadratic/modules/masks_nd.py
+++ b/nvsubquadratic/modules/masks_nd.py
@@ -189,6 +189,7 @@ class GaussianModulationND(torch.nn.Module):
 
         self.min_std = float(min_std)
         self.max_std = float(max_std)
+        self._min_step = float(min_step)
 
         # Create weight parameter
         init_std_per_channel = torch.logspace(math.log10(init_std_low), math.log10(init_std_high), num_channels)
@@ -239,11 +240,25 @@ class GaussianModulationND(torch.nn.Module):
         std = std.clamp(min=self.min_std, max=self.max_std)
         return std
 
+    @staticmethod
+    def _mask_value(std: float, position: float) -> float:
+        """1D Gaussian mask value: exp(-0.5 * (position / std)^2)."""
+        return math.exp(-0.5 * (position / std) ** 2)
+
     def extra_repr(self):
         """Additional printing for the GaussianModulationND class."""
+        std = self._compute_std().detach()  # [data_dim, num_channels]
+        narrowest = std.min().item()
+        widest = std.max().item()
+        step = self._min_step
         return (
-            f"data_dim={self.data_dim}, num_channels={self.num_channels}, min_std={self.min_std}, "
-            f"max_std={self.max_std}, parametrization='{self.parametrization}'"
+            f"data_dim={self.data_dim}, num_channels={self.num_channels}, "
+            f"parametrization='{self.parametrization}'\n"
+            f"  narrowest ch: mask@step={self._mask_value(narrowest, step):.4f}, "
+            f"mask@boundary={self._mask_value(narrowest, 1.0):.4f} (std={narrowest:.4f})\n"
+            f"  widest ch:    mask@step={self._mask_value(widest, step):.4f}, "
+            f"mask@boundary={self._mask_value(widest, 1.0):.4f} (std={widest:.4f})\n"
+            f"  std bounds: [{self.min_std:.4f}, {self.max_std:.4f}]"
         )
 
     def forward(self, grid: torch.Tensor, x: torch.Tensor) -> torch.Tensor:

--- a/nvsubquadratic/modules/vit5_attention.py
+++ b/nvsubquadratic/modules/vit5_attention.py
@@ -4,7 +4,7 @@ Key differences from the base Attention module:
 - QK-Norm uses RMSNorm (learnable, per-head) instead of L2 normalization.
 - RoPE is applied only to patch tokens (not cls token).
 - Register tokens get their own high-frequency RoPE.
-- Operates on flattened sequences [B, T, C] where T = 1 (cls) + N (patches) + R (registers).
+- Operates on flattened sequences [B, T, C] where T = N (patches) + 1 (cls) + R (registers).
 
 Optimizations vs naive implementation:
 - RoPE cos/sin are precomputed as registered buffers (CUDA-graph safe, no graph breaks).
@@ -104,7 +104,8 @@ def _rotate_half_per_axis(x: torch.Tensor) -> torch.Tensor:
 class ViT5Attention(nn.Module):
     """ViT-5 multi-head self-attention with RMSNorm QK-Norm and register-aware RoPE.
 
-    Expects input as [B, T, C] where T = 1 (cls) + num_patches + num_registers.
+    Expects input as [B, T, C] where T = num_patches + (1 if has_cls) + num_registers.
+    Token layout: [patches, (CLS), registers] -- no padding (stripped by the network).
     The module includes its own QKV and output projections (unlike the base Attention
     which is wrapped in QKVSequenceMixer).
 
@@ -124,6 +125,8 @@ class ViT5Attention(nn.Module):
         scale: Attention scaling factor. When None, defaults to ``head_dim ** -0.5``.
         init_fn_qkv_proj: Optional callable ``fn(tensor) -> None`` applied to the
             QKV projection weights. When None, weights keep PyTorch's default init.
+        has_cls: Whether the sequence contains a CLS token (between patches and
+            registers in the token layout). Defaults to True.
         init_fn_out_proj: Optional callable ``fn(tensor) -> None`` applied to the
             output projection weights. When None, weights keep PyTorch's default init.
     """
@@ -135,6 +138,7 @@ class ViT5Attention(nn.Module):
         num_patches_h: int,
         num_patches_w: int,
         num_registers: int = 4,
+        has_cls: bool = True,
         qk_norm: Optional[LazyConfig] = None,
         rope_base: float = 10000.0,
         reg_rope_base: float = 100.0,
@@ -190,9 +194,12 @@ class ViT5Attention(nn.Module):
         #   - are NOT serialised into checkpoints (persistent=False), since they
         #     are deterministically reconstructed from __init__ args.
         #
+        # Token layout: [patches, (CLS), registers]
         # Layout per token position: [Y_frequencies | X_frequencies]
-        # CLS token gets cos=1, sin=0 (identity — no positional bias).
+        # CLS token (when present) gets cos=1, sin=0 (identity — no positional bias).
         # Register tokens get their own high-frequency RoPE (theta=100).
+        self.has_cls = has_cls
+
         patch_cos, patch_sin = _build_2d_rope_flat(
             num_patches_h,
             num_patches_w,
@@ -200,10 +207,12 @@ class ViT5Attention(nn.Module):
             rope_base,
         )
 
-        parts_cos = [torch.ones(1, self.head_dim)]  # cls: cos=1 (no rotation)
-        parts_sin = [torch.zeros(1, self.head_dim)]  # cls: sin=0 (no rotation)
-        parts_cos.append(patch_cos)
-        parts_sin.append(patch_sin)
+        parts_cos = [patch_cos]
+        parts_sin = [patch_sin]
+
+        if has_cls:
+            parts_cos.append(torch.ones(1, self.head_dim))  # CLS: cos=1 (no rotation)
+            parts_sin.append(torch.zeros(1, self.head_dim))  # CLS: sin=0 (no rotation)
 
         if num_registers > 0:
             reg_cos, reg_sin = _build_2d_rope_flat(
@@ -215,7 +224,7 @@ class ViT5Attention(nn.Module):
             parts_cos.append(reg_cos)
             parts_sin.append(reg_sin)
 
-        # [T, head_dim] where T = 1 + H*W + R
+        # [T, head_dim] where T = H*W + (1 if has_cls) + R
         self.register_buffer("rope_cos", torch.cat(parts_cos, dim=0), persistent=False)
         self.register_buffer("rope_sin", torch.cat(parts_sin, dim=0), persistent=False)
 
@@ -278,7 +287,8 @@ class ViT5Attention(nn.Module):
         """Forward pass.
 
         Args:
-            x: [B, T, C] where T = 1 (cls) + num_patches + num_registers.
+            x: [B, T, C] where T = num_patches + (1 if has_cls) + num_registers.
+                Token layout: [patches, (CLS), registers].
 
         Returns:
             [B, T, C]

--- a/nvsubquadratic/modules/vit5_hyena_adapter.py
+++ b/nvsubquadratic/modules/vit5_hyena_adapter.py
@@ -4,10 +4,10 @@ The ViT5 architecture processes [B, T, C] sequences. 2D mixers like Hyena expect
 [B, H, W, C] spatial grids. This adapter reshapes the flat token sequence to a 2D
 grid, applies the inner mixer, and reshapes back.
 
-All token ordering (CLS position, register placement) is handled upstream by the
-network (e.g. ViT5ClassificationNet with prepend_registers=True), so this adapter
-treats the entire sequence as a flat spatial grid — it does not know or care about
-which tokens are CLS, registers, or patches.
+Token ordering is handled upstream by the network (ViT5ClassificationNet).
+The standard layout is [patches, CLS, registers, padding] where padding
+ensures T is divisible by grid_w.  This adapter is layout-agnostic: it treats
+the entire sequence as a flat spatial grid reshaped to (T // grid_w, grid_w).
 """
 
 import torch
@@ -59,11 +59,9 @@ class ViT5HyenaAdapter(nn.Module):
 
         Args:
             x: [B, T, C] token sequence. T must be divisible by grid_w.
-                When registers are present, Hyena accomodates them at the first row of the 2D grid,
-                making the token at position (0, 0) the CLS token, and the (0, 1), ..., (0, num_registers-1)
-                the register tokens.
-
-            IMPORTANT: In the future we can have M < grid_w registers by appending grid_w - M zeros to the row.
+                Standard layout: [patches (H*W), CLS (1), registers (R), padding (P)].
+                The adapter is layout-agnostic and reshapes the full sequence
+                to a 2D grid of shape (T // grid_w, grid_w).
             **mixer_kwargs: Forwarded to the inner mixer (e.g. ``conditioning`` for FiLM).
 
         Returns:

--- a/nvsubquadratic/modules/vit5_residual_block.py
+++ b/nvsubquadratic/modules/vit5_residual_block.py
@@ -34,8 +34,9 @@ class ViT5ResidualBlock(nn.Module):
         num_registers: Number of register tokens (needed for extraction). Only used
             when register_pooling_cfg is provided.
         register_start_idx: Start index of register tokens in the sequence.
-            Default 1 for [CLS, regs, patches] layout; set to 0 for GAP models
-            without CLS where registers are prepended directly.
+            With the standard layout [patches, CLS, registers, ...], this is
+            ``num_patches + 1`` (CLS readout) or ``num_patches`` (GAP readout).
+            Typically auto-computed by the network and injected at construction.
         grn_cfg: Optional LazyConfig for GlobalResponseNorm (ConvNeXt V2).
             When provided, GRN is applied after the sequence mixer output
             to promote inter-channel feature competition.
@@ -155,7 +156,7 @@ class ViT5ResidualBlock(nn.Module):
         """Forward pass.
 
         Args:
-            x: [B, T, C] where T = num_tokens (cls + patches + registers).
+            x: [B, T, C] where T = num_tokens (patches + cls + registers [+ padding]).
             condition: Unused, kept for API compatibility with ResidualBlock.
 
         Returns:

--- a/nvsubquadratic/networks/vit5_classification.py
+++ b/nvsubquadratic/networks/vit5_classification.py
@@ -3,9 +3,20 @@
 Implements the full ViT-5 architecture for ImageNet classification:
 - Patch embedding via Conv2d (Patchify)
 - Learnable absolute positional embeddings (APE) on patch tokens
-- Prepended CLS token, appended register tokens
+- Token layout: [patches, CLS, registers, padding]
 - N x ViT5ResidualBlock (pre-norm, attention, LayerScale, DropPath, MLP)
 - Final norm on CLS token -> linear head
+
+Token ordering convention:
+  [patches (H*W), CLS (1), registers (R), padding (P)]
+where padding has length ``(-num_non_pad) % grid_w`` to make the total
+sequence length divisible by ``grid_w`` for 2D spatial mixers (Hyena).
+Attention blocks receive the sequence with padding stripped; Hyena blocks
+receive the full padded sequence.
+
+Supports **hybrid** architectures with interleaved block types via
+``layer_pattern`` + ``layer_types`` (e.g. ``"HA" * 6`` for alternating
+Hyena/Attention).
 
 Reference: Wang et al., "ViT-5: Vision Transformers for The Mid-2020s", 2026.
 """
@@ -19,8 +30,46 @@ from einops import rearrange
 from nvsubquadratic.lazy_config import LazyConfig, instantiate
 
 
+def _compute_drop_path_rates(max_rate: float, num_blocks: int, schedule: str) -> list[float]:
+    """Compute per-layer drop path rates according to the given schedule.
+
+    Args:
+        max_rate: Maximum stochastic depth drop probability.
+        num_blocks: Total number of blocks.
+        schedule: ``"constant"`` (same rate for all layers) or ``"linear"``
+            (ramp from 0 to ``max_rate`` across depth).
+
+    Returns:
+        List of per-layer drop path rates (length ``num_blocks``).
+    """
+    if schedule == "constant":
+        return [max_rate] * num_blocks
+    elif schedule == "linear":
+        if num_blocks <= 1:
+            return [max_rate]
+        return [max_rate * i / (num_blocks - 1) for i in range(num_blocks)]
+    else:
+        raise ValueError(f"Unknown drop_path_schedule: {schedule!r}. Expected 'constant' or 'linear'.")
+
+
 class ViT5ClassificationNet(nn.Module):
     """ViT-5 classification network.
+
+    Token layout: ``[patches (H*W), CLS (1), registers (R), padding (P)]``.
+
+    Padding makes ``T % grid_w == 0`` for 2D spatial mixers (Hyena).
+    Attention blocks receive the sequence with padding stripped; Hyena blocks
+    receive the full padded sequence.
+
+    Supports two block-stacking modes (mutually exclusive):
+
+    1. **Homogeneous** (default): a single ``block_cfg`` is replicated
+       ``num_blocks`` times.
+
+    2. **Hybrid / interleaved**: ``layer_pattern`` + ``layer_types`` define
+       per-layer block types.  For example, ``layer_pattern="HA" * 6`` with
+       ``layer_types={"H": hyena_cfg, "A": attn_cfg}`` creates 12 blocks
+       alternating between Hyena and Attention.
 
     Args:
         in_channels: Number of input channels (3 for RGB).
@@ -30,30 +79,35 @@ class ViT5ClassificationNet(nn.Module):
         patch_size: Patch size for patchification.
         image_size: Input image size (assumes square).
         num_registers: Number of learnable register tokens.
-        block_cfg: LazyConfig for ViT5ResidualBlock.
+        block_cfg: LazyConfig for ViT5ResidualBlock (homogeneous mode).
+            Mutually exclusive with ``layer_pattern``/``layer_types``.
         norm_cfg: LazyConfig for the normalization layer (RMSNorm).
-            When ``readout="register_concat"``, this norm is applied to the
-            concatenated compressed register vector (dim = ``num_registers * neck_dim``),
-            so the caller must pass ``dim=num_registers * neck_dim`` in the config.
         dropout_rate: Dropout rate applied before the classification head.
         readout: Classification readout strategy.
-            ``"cls"``: prepend a learnable CLS token and read it out.
+            ``"cls"``: append a learnable CLS token after patches and read it out.
             ``"gap"``: global average pooling over patch tokens.
             ``"register_concat"``: gather register tokens after all blocks,
             compress each via a shared neck linear, concatenate, and project.
         neck_compression_ratio: Compression ratio for ``register_concat`` readout.
-            Each register is projected from ``hidden_dim`` to
-            ``hidden_dim // neck_compression_ratio``.  The classification head
-            input dimension becomes
-            ``num_registers * (hidden_dim // neck_compression_ratio)``.
             Required when ``readout="register_concat"``.
-        prepend_registers: If True, register tokens are placed before patch tokens.
-            With CLS: [CLS, regs, patches]. Without CLS: [regs, zero_pad, patches]
-            where zero_pad fills the register row to grid width (image_size // patch_size)
-            for clean 2D reshape in spatial mixers like Hyena.
         reg_init: Initialization strategy for register tokens.
-            "trunc_normal" (default) uses truncated normal with std=0.02.
-            "zeros" initializes registers to zero.
+            ``"trunc_normal"`` (default) or ``"zeros"``.
+        layer_pattern: Pattern string defining per-layer block types (hybrid
+            mode).  Each character maps to a key in ``layer_types``.
+            Length must equal ``num_blocks``.  Example: ``"HA" * 6``.
+        layer_types: Dict mapping pattern characters to block LazyConfigs.
+            Required when ``layer_pattern`` is set.
+        padding_types: Set of ``layer_pattern`` characters whose blocks need
+            the full padded sequence (e.g. Hyena).  Blocks whose character is
+            NOT in this set receive the sequence with padding stripped.
+            Only relevant when ``layer_pattern`` is used *and* ``pad_size > 0``.
+            Default: ``{"H"}``.
+        max_drop_path_rate: Maximum stochastic depth drop probability.
+            Per-layer rates are computed according to ``drop_path_schedule``
+            and injected into each block config at construction time.
+        drop_path_schedule: How drop path rates are distributed across depth.
+            ``"constant"``: every layer gets ``max_drop_path_rate``.
+            ``"linear"``: ramp from 0 to ``max_drop_path_rate`` across depth.
     """
 
     def __init__(
@@ -65,13 +119,17 @@ class ViT5ClassificationNet(nn.Module):
         patch_size: int,
         image_size: int,
         num_registers: int,
-        block_cfg: LazyConfig,
         norm_cfg: LazyConfig,
         readout: Literal["cls", "gap", "register_concat"],
+        block_cfg: LazyConfig | None = None,
         dropout_rate: float = 0.0,
         neck_compression_ratio: int | None = None,
-        prepend_registers: bool = False,
         reg_init: Literal["trunc_normal", "zeros"] = "trunc_normal",
+        layer_pattern: str | None = None,
+        layer_types: dict[str, LazyConfig] | None = None,
+        padding_types: set[str] | None = None,
+        max_drop_path_rate: float = 0.0,
+        drop_path_schedule: Literal["constant", "linear"] = "constant",
     ):
         """Initialize ViT-5 classification network."""
         super().__init__()
@@ -81,7 +139,7 @@ class ViT5ClassificationNet(nn.Module):
         self.num_registers = num_registers
         self.patch_size = patch_size
         self.image_size = image_size
-        self.prepend_registers = prepend_registers
+        self.layer_pattern = layer_pattern
 
         self.readout = readout
         self.use_cls_token = readout == "cls"
@@ -99,6 +157,7 @@ class ViT5ClassificationNet(nn.Module):
         num_patches_h = image_size // patch_size
         num_patches_w = image_size // patch_size
         self.num_patches = num_patches_h * num_patches_w
+        self._grid_w = num_patches_w
 
         # Patch embedding (non-overlapping Conv2d, no bias — pos_embed absorbs the offset)
         self.patch_embed = nn.Conv2d(
@@ -117,7 +176,7 @@ class ViT5ClassificationNet(nn.Module):
         else:
             self.cls_token = None
 
-        # Absolute positional embeddings for patch tokens only (not cls, not registers)
+        # Absolute positional embeddings for patch tokens only (not CLS, not registers)
         self.pos_embed = nn.Parameter(torch.zeros(1, self.num_patches, hidden_dim))
         self.pos_embed._no_weight_decay = True
 
@@ -127,29 +186,54 @@ class ViT5ClassificationNet(nn.Module):
         else:
             self.reg_token = None
 
-        # Zero-padding buffer: fills the register row to grid width so the
-        # token sequence reshapes cleanly into a 2-D grid for spatial mixers.
-        # CLS-row layout:  [CLS, regs, pad, patches]  →  pad = W-1-M
-        # GAP layout:      [regs, pad, patches]        →  pad = W-M
-        assert num_registers <= num_patches_w, (
-            f"num_registers ({num_registers}) > grid width ({num_patches_w}); "
-            "registers must fit in a single row for 2D reshape"
-        )
-        self._register_row_width = num_patches_w
-        if num_registers > 0 and prepend_registers:
-            if self.use_cls_token:
-                pad_size = num_patches_w - 1 - num_registers  # CLS occupies 1 slot
-            else:
-                pad_size = num_patches_w - num_registers
-            if pad_size > 0:
-                self.register_buffer("reg_zero_pad", torch.zeros(1, pad_size, hidden_dim), persistent=False)
-            else:
-                self.reg_zero_pad = None
-        else:
-            self.reg_zero_pad = None
+        # Token layout: [patches (H*W), CLS (1?), registers (R), padding (P)]
+        # Padding makes T divisible by grid_w for 2D spatial mixers.
+        num_non_pad = self.num_patches + (1 if self.use_cls_token else 0) + num_registers
+        pad_size = (-num_non_pad) % num_patches_w
+        self._pad_size = pad_size
+        self._num_non_pad = num_non_pad
 
-        # Transformer blocks
-        self.blocks = nn.ModuleList([instantiate(block_cfg) for _ in range(num_blocks)])
+        if pad_size > 0:
+            self.register_buffer("_zero_pad", torch.zeros(1, pad_size, hidden_dim), persistent=False)
+        else:
+            self._zero_pad = None
+
+        # Per-block padding flag: True = block needs the full padded sequence
+        if padding_types is None:
+            padding_types = {"H"}
+        if layer_pattern is not None:
+            self._block_needs_padding = [ch in padding_types for ch in layer_pattern]
+        else:
+            self._block_needs_padding = [False] * num_blocks
+
+        # Build per-layer block configs: either from layer_pattern or by
+        # replicating a single block_cfg.  Both paths produce the same
+        # list[LazyConfig] of length num_blocks fed to a single loop.
+        if layer_pattern is not None:
+            assert layer_types is not None, "layer_types is required when layer_pattern is set"
+            assert len(layer_pattern) == num_blocks, (
+                f"layer_pattern length ({len(layer_pattern)}) != num_blocks ({num_blocks})"
+            )
+            assert block_cfg is None, "block_cfg and layer_pattern are mutually exclusive"
+            for ch in layer_pattern:
+                assert ch in layer_types, f"Unknown layer type '{ch}' in layer_pattern; available: {set(layer_types)}"
+            block_cfgs = [layer_types[ch] for ch in layer_pattern]
+        else:
+            assert block_cfg is not None, "Either block_cfg or (layer_pattern + layer_types) must be provided"
+            block_cfgs = [block_cfg] * num_blocks
+
+        # Auto-compute register_start_idx for the new layout:
+        # [patches, CLS, registers, ...] -> registers start after patches + CLS
+        register_start_idx = self.num_patches + (1 if self.use_cls_token else 0)
+
+        drop_path_rates = _compute_drop_path_rates(max_drop_path_rate, num_blocks, drop_path_schedule)
+
+        self.blocks = nn.ModuleList(
+            [
+                instantiate(cfg, drop_path_rate=drop_path_rates[i], register_start_idx=register_start_idx)
+                for i, cfg in enumerate(block_cfgs)
+            ]
+        )
 
         # Register-concat readout: shared neck compression
         if self.readout == "register_concat":
@@ -197,25 +281,14 @@ class ViT5ClassificationNet(nn.Module):
         """Count FLOPs for a full ViT-5 classification forward pass (one sample).
 
         Pipeline:
-          1. Patch embedding (Conv2d(in_channels, D, kernel_size=P, stride=P)):
-               2 * in_channels * D * P² * num_patches
-             Each of the ``num_patches`` output positions has a receptive field
-             of P x P x in_channels → P² * in_channels MACs = 2 * P² * in_ch * D FLOPs.
-          2. Positional embedding addition:  num_patches * D  (elementwise add).
-          3. Transformer blocks:  sum of ``block.flop_count(T, inference)``
-             where T is the total token count (see below).
-          4. Output norm (RMSNorm on 1 CLS token or GAP result):
-               ``self.out_norm.flop_count(1)``
-             For GAP models, the averaging itself costs num_patches * D adds.
-          5. Classification head (Linear(D, num_classes)):
-               2 * D * num_classes
+          1. Patch embedding (Conv2d):  2 * in_ch * D * P^2 * num_patches
+          2. Positional embedding add:  num_patches * D
+          3. Transformer blocks:        sum of block.flop_count(T)
+          4. Output norm:               self.out_norm.flop_count(1)
+          5. Classification head:       2 * head_dim * num_classes
 
-        Token count T:
-          - With CLS + prepend_registers: 1 + num_registers + num_patches
-          - With CLS + append_registers: 1 + num_patches + num_registers
-          - Without CLS + prepend_registers: register_row_width + num_patches
-          - Without CLS/registers: num_patches
-          The ordering doesn't affect FLOP count — only T matters.
+        Token count T = num_non_pad + pad_size.  Attention blocks see
+        T_attn = num_non_pad (padding stripped).
 
         Args:
             inference: Passed through to each block for kernel caching decisions.
@@ -230,32 +303,21 @@ class ViT5ClassificationNet(nn.Module):
 
         flops = 0
 
-        # 1. Patch embedding: Conv2d(in_ch, D, P, stride=P) on (image_size, image_size)
+        # 1. Patch embedding
         flops += 2 * in_channels * D * P * P * num_patches
 
         # 2. Positional embedding addition
         flops += num_patches * D
 
-        # 3. Total token count
-        T = num_patches
-        if self.use_cls_token:
-            T += 1
-        if self.num_registers > 0:
-            if self.prepend_registers:
-                if self.use_cls_token:
-                    T += self._register_row_width - 1  # regs + padding (CLS already counted)
-                else:
-                    T += self._register_row_width  # regs + padding (no CLS)
-            else:
-                T += self.num_registers
+        # 3. Transformer blocks (attention blocks see fewer tokens)
+        T_full = self._num_non_pad + self._pad_size
+        T_no_pad = self._num_non_pad
+        for i, block in enumerate(self.blocks):
+            T_block = T_full if self._block_needs_padding[i] else T_no_pad
+            flops += block.flop_count(T_block, inference=inference)
 
-        # 4. Transformer blocks
-        for block in self.blocks:
-            flops += block.flop_count(T, inference=inference)
-
-        # 5. Output norm + readout
+        # 4. Output norm + readout
         if self.readout == "register_concat":
-            # Neck linear: R * (2 * D * neck_dim)
             flops += self.num_registers * 2 * D * self.neck_dim
             head_dim = self.num_registers * self.neck_dim
             flops += self.out_norm.flop_count(1)
@@ -267,13 +329,17 @@ class ViT5ClassificationNet(nn.Module):
             head_dim = D
             flops += self.out_norm.flop_count(1)
 
-        # 6. Classification head
+        # 5. Classification head
         flops += 2 * head_dim * self.num_classes
 
         return flops
 
     def forward(self, input_and_condition: dict[str, torch.Tensor]) -> dict[str, torch.Tensor]:
         """Forward pass.
+
+        Token layout: ``[patches (H*W), CLS (1?), registers (R), padding (P)]``.
+        Attention blocks see ``[patches, CLS, registers]`` (padding stripped).
+        Hyena blocks see the full padded sequence.
 
         Args:
             input_and_condition: Dict with keys "input" (images [B, H, W, C]) and "condition" (unused).
@@ -288,64 +354,41 @@ class ViT5ClassificationNet(nn.Module):
         x = self.patch_embed(x)  # [B, hidden_dim, H', W']
         x = rearrange(x, "b c h w -> b (h w) c")  # [B, num_patches, hidden_dim]
 
-        # Add absolute positional embeddings
+        # Add absolute positional embeddings (patches only)
         x = x + self.pos_embed
 
         B = x.shape[0]
 
-        # Prepend CLS token (when enabled)
+        # Build token sequence: [patches, CLS?, registers?, padding?]
+        parts = [x]
         if self.cls_token is not None:
-            cls_tokens = self.cls_token.expand(B, -1, -1)
-            x = torch.cat([cls_tokens, x], dim=1)  # [B, 1 + num_patches, C]
-
-        # Insert register tokens
+            parts.append(self.cls_token.expand(B, -1, -1))
         if self.reg_token is not None:
-            reg_tokens = self.reg_token.expand(B, -1, -1)
-            if self.prepend_registers and self.cls_token is not None:
-                # [CLS, regs, (pad), patches] — enables direct 2D reshape for spatial mixers
-                if self.reg_zero_pad is not None:
-                    pad = self.reg_zero_pad.expand(B, -1, -1)
-                    x = torch.cat([x[:, :1, :], reg_tokens, pad, x[:, 1:, :]], dim=1)
-                else:
-                    x = torch.cat([x[:, :1, :], reg_tokens, x[:, 1:, :]], dim=1)
-            elif self.prepend_registers:
-                # [regs, zero_pad, patches] — GAP model without CLS
-                if self.reg_zero_pad is not None:
-                    pad = self.reg_zero_pad.expand(B, -1, -1)
-                    x = torch.cat([reg_tokens, pad, x], dim=1)
-                else:
-                    x = torch.cat([reg_tokens, x], dim=1)
-            else:
-                x = torch.cat([x, reg_tokens], dim=1)
+            parts.append(self.reg_token.expand(B, -1, -1))
+        if self._zero_pad is not None:
+            parts.append(self._zero_pad.expand(B, -1, -1))
+        if len(parts) > 1:
+            x = torch.cat(parts, dim=1)
 
         # Apply transformer blocks
-        for block in self.blocks:
-            x = block(x)
-
-        if self.readout == "register_concat":
-            # Gather register tokens, compress via neck, concatenate
-            if self.prepend_registers and self.cls_token is not None:
-                reg_start = 1  # [CLS, regs, (pad), patches]
-            elif self.prepend_registers:
-                reg_start = 0  # [regs, zero_pad, patches]
+        pad_size = self._pad_size
+        for i, block in enumerate(self.blocks):
+            if pad_size > 0 and not self._block_needs_padding[i]:
+                x_no_pad = x[:, :-pad_size]
+                x_no_pad = block(x_no_pad)
+                x = torch.cat([x_no_pad, x[:, -pad_size:]], dim=1)
             else:
-                reg_start = x.shape[1] - self.num_registers  # [..., regs]
+                x = block(x)
+
+        # Readout (indices based on [patches, CLS, registers, padding] layout)
+        if self.readout == "register_concat":
+            reg_start = self.num_patches + (1 if self.use_cls_token else 0)
             regs = x[:, reg_start : reg_start + self.num_registers, :]
             out = self.register_neck(regs).flatten(start_dim=1)  # [B, R * neck_dim]
         elif self.use_cls_token:
-            out = x[:, 0]
+            out = x[:, self.num_patches]  # CLS is right after patches
         else:
-            # Global average pool over patch tokens, excluding register tokens
-            if self.prepend_registers and self.num_registers > 0 and self.cls_token is not None:
-                # [CLS, regs, (pad), patches] — skip entire first row
-                out = x[:, self._register_row_width :].mean(dim=1)
-            elif self.prepend_registers and self.num_registers > 0:
-                # [regs, zero_pad, patches] — skip entire register row
-                out = x[:, self._register_row_width :].mean(dim=1)
-            elif self.num_registers > 0:
-                out = x[:, : -self.num_registers].mean(dim=1)
-            else:
-                out = x.mean(dim=1)
+            out = x[:, : self.num_patches].mean(dim=1)  # GAP over patches only
 
         out = self.out_norm(out)
         out = self.dropout(out)

--- a/slurm/queue.sh
+++ b/slurm/queue.sh
@@ -42,7 +42,7 @@ done
 
 submit_job() {
     local dep_flag="${1:-}"
-    sbatch ${dep_flag} "${SBATCH_EXTRA_ARGS[@]+"${SBATCH_EXTRA_ARGS[@]}"}" "${SCRIPT_NAME}" "${CONFIG}" \
+    sbatch ${dep_flag} "${SCRIPT_NAME}" "${CONFIG}" "${SBATCH_EXTRA_ARGS[@]+"${SBATCH_EXTRA_ARGS[@]}"}" \
         | awk '{print $4}'
 }
 

--- a/slurm/submit_hybrid.sh
+++ b/slurm/submit_hybrid.sh
@@ -1,0 +1,191 @@
+#!/bin/bash
+#SBATCH --account=healthcareeng_bionemo
+#SBATCH --nodes=1
+#SBATCH --partition=batch,backfill
+#SBATCH --ntasks-per-node=8
+#SBATCH --time=04:00:00
+#SBATCH --mem=0
+#SBATCH --mail-type=FAIL
+#SBATCH --exclusive
+#SBATCH --job-name=healthcareeng_bionemo-nvsubq.v5hybrid
+
+# Usage (from repo root):
+#   sbatch slurm/submit_hybrid.sh examples/vit5_imagenet/vit5_hybrid/full_attention.py
+#   sbatch slurm/submit_hybrid.sh examples/vit5_imagenet/vit5_hybrid/full_attention.py \
+#       net.patch_size=8 dataset.batch_size=64 train.accumulate_grad_steps=4
+#
+# Via queue.sh for chaining (recommended for 800-epoch runs):
+#   bash slurm/queue.sh slurm/submit_hybrid.sh 12 \
+#       examples/vit5_imagenet/vit5_hybrid/full_attention.py
+
+set -x
+
+if [ -z "${1:-}" ]; then
+    echo "Usage: sbatch slurm/submit_hybrid.sh <config.py> [overrides...]"
+    exit 1
+fi
+
+# Capture start time immediately
+JOB_START_TIMESTAMP=$(date +%s)
+echo "Start time captured: ${JOB_START_TIMESTAMP}"
+
+# Container mount paths
+CONTAINER_DATA="/workspace/data"
+CONTAINER_RESULTS="/workspace/results"
+
+# ============================================================================
+# Configuration
+# ============================================================================
+TIME_LIMIT_HOURS=4
+EXPERIMENT_NAME="$(basename "${1%.py}")"
+CONFIG_FILE="$1"; shift
+
+CONFIG_OVERRIDES="num_nodes=${SLURM_JOB_NUM_NODES}"
+CONFIG_OVERRIDES="${CONFIG_OVERRIDES} experiment_dir=${CONTAINER_RESULTS}"
+CONFIG_OVERRIDES="${CONFIG_OVERRIDES} compile_mode=max-autotune-no-cudagraphs"
+# Append any extra overrides passed on the command line
+for arg in "$@"; do
+    CONFIG_OVERRIDES="${CONFIG_OVERRIDES} ${arg}"
+done
+
+# Container image
+IMAGE_NAME="${SQSH_IMAGE:-/lustre/fsw/healthcareeng_bionemo/amoradzadeh/hyena/enroot/nvsubquadratic-slurm-x86_64-04-17-2026.sqsh}"
+
+# Host paths
+WORKDIR="${PWD}"
+RUNS_DIR="${WORKDIR}/runs"
+DATA_DIR="${IMAGENET_HOST_DIR:-/lustre/fsw/healthcareeng_bionemo/amoradzadeh/hyena}"
+
+# Create necessary directories
+mkdir -p "${RUNS_DIR}"
+
+# ============================================================================
+# Run naming (deterministic hash -> same dir across restarts)
+# ============================================================================
+RUN_NAME_HASH=$(echo "${CONFIG_FILE} ${CONFIG_OVERRIDES} ${EXPERIMENT_NAME}" | md5sum | awk '{print $1}' | cut -c1-8)
+RUN_NAME="run_${RUN_NAME_HASH}"
+
+EXPERIMENT_DIR="${RUNS_DIR}/${EXPERIMENT_NAME}"
+RESULTS_PATH="${EXPERIMENT_DIR}/${RUN_NAME}"
+
+mkdir -p "${EXPERIMENT_DIR}"
+mkdir -p "${RESULTS_PATH}"
+
+# ============================================================================
+# W&B run ID -- persisted across restarts so resume attaches to the same run
+# ============================================================================
+if [ -f "${RESULTS_PATH}/run.id" ]; then
+    RUN_ID=$(<"${RESULTS_PATH}/run.id")
+    echo "Resuming with existing W&B run ID: ${RUN_ID}"
+else
+    array=()
+    for i in {a..z} {A..Z} {0..9}; do
+        array[$RANDOM]=$i
+    done
+    RUN_ID=$(printf %s "${array[@]::8}")
+    echo "${RUN_ID}" > "${RESULTS_PATH}/run.id"
+    echo "Generated new W&B run ID: ${RUN_ID}"
+fi
+
+echo "$(date): Job ${SLURM_JOB_ID} started (W&B run ID: ${RUN_ID})" >> "${RESULTS_PATH}/job_chain.log"
+
+# ============================================================================
+# Container mounts
+# ============================================================================
+MOUNTS="${DATA_DIR}:${CONTAINER_DATA}"
+MOUNTS="${MOUNTS},${RESULTS_PATH}:${CONTAINER_RESULTS}"
+MOUNTS="${MOUNTS},${WORKDIR}:/workspaces/nvSubquadratic-private"
+MOUNTS="${MOUNTS},$HOME/.cache:/root/.cache"
+
+if [ -f "$HOME/.netrc" ]; then
+    MOUNTS="${MOUNTS},$HOME/.netrc:/root/.netrc"
+fi
+
+# Code is baked into the container
+WORK_DIR="/workspaces/nvSubquadratic-private"
+CONFIG_PATH="${WORK_DIR}/${CONFIG_FILE}"
+
+echo "================================================"
+echo "Experiment:    ${EXPERIMENT_NAME}"
+echo "Job ID:        ${SLURM_JOB_ID}"
+echo "Run Name:      ${RUN_NAME}"
+echo "Node(s):       ${SLURM_NODELIST}"
+echo "Num nodes:     ${SLURM_JOB_NUM_NODES}"
+echo "GPUs per node: ${SLURM_NTASKS_PER_NODE}"
+echo "Total GPUs:    $((${SLURM_JOB_NUM_NODES} * ${SLURM_NTASKS_PER_NODE}))"
+echo "Config:        ${CONFIG_FILE}"
+echo "Overrides:     ${CONFIG_OVERRIDES}"
+echo "Container:     ${IMAGE_NAME}"
+echo "Results:       ${RESULTS_PATH}"
+echo "Mounts:        ${MOUNTS}"
+echo "================================================"
+
+# ============================================================================
+# Environment Setup
+# ============================================================================
+export WANDB_API_KEY="${WANDB_API_KEY:-}"
+export HF_TOKEN="${HF_TOKEN:-}"
+export PYTHONPATH="."
+export DALI_NO_MMAP=1
+export TRITON_CACHE_DIR="/tmp/triton_${SLURM_JOB_ID}"
+export TORCHINDUCTOR_FX_GRAPH_CACHE=0
+export TORCH_NCCL_AVOID_RECORD_STREAMS=1
+export PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True
+
+# ImageNet paths (container-side) -- imagenet_folder is the ImageFolder layout
+export IMAGENET_PATH="${CONTAINER_DATA}/imagenet_folder"
+export IMAGENET_FOLDER_PATH="${CONTAINER_DATA}/imagenet_folder"
+export LOCAL_STAGING_DIR="${CONTAINER_DATA}/imagenet_folder"
+
+# ============================================================================
+# Autoresume
+# ============================================================================
+if [ -f "${RESULTS_PATH}/checkpoints/last.ckpt" ]; then
+    echo "Found existing checkpoint -- enabling autoresume"
+    AUTORESUME_ARG="autoresume.enabled=True"
+else
+    echo "No existing checkpoint found, starting fresh"
+    AUTORESUME_ARG="wandb.run_id=${RUN_ID}"
+fi
+
+# ============================================================================
+# Training command
+# ============================================================================
+read -r -d '' PYTHON_CMD <<EOF || true
+export HF_HOME=${CONTAINER_DATA}/.hf && \
+export HF_HUB_CACHE=${CONTAINER_DATA}/.hf/hub && \
+export HF_DATASETS_CACHE=${CONTAINER_DATA}/.hf/datasets && \
+export TRANSFORMERS_CACHE=${CONTAINER_DATA}/.hf/transformers && \
+export WANDB_DIR=${CONTAINER_RESULTS}/wandb && \
+export WANDB_CACHE_DIR=${CONTAINER_RESULTS}/.cache/wandb && \
+export WANDB_DATA_DIR=${CONTAINER_RESULTS}/.wandbstage && \
+cd ${WORK_DIR} && \
+python -m experiments.run \
+    --config ${CONFIG_PATH} \
+    ${CONFIG_OVERRIDES} \
+    ${AUTORESUME_ARG} \
+    train.run_start_time=${JOB_START_TIMESTAMP} \
+    train.run_time_limit_hours=${TIME_LIMIT_HOURS}
+EOF
+
+echo "Starting training at $(date)"
+echo "Command: ${PYTHON_CMD}"
+
+# ============================================================================
+# Launch
+# ============================================================================
+srun \
+    --output "${RESULTS_PATH}/slurm-%j-%n.out" \
+    --error  "${RESULTS_PATH}/error-%j-%n.out" \
+    --export=ALL \
+    --container-image="${IMAGE_NAME}" \
+    --container-mounts="${MOUNTS}" \
+    bash -c "${PYTHON_CMD}"
+
+TRAIN_EXIT_CODE=$?
+
+echo "Training exited with code: ${TRAIN_EXIT_CODE} at $(date)"
+echo "$(date): Job ${SLURM_JOB_ID} completed with exit code ${TRAIN_EXIT_CODE}" >> "${RESULTS_PATH}/job_chain.log"
+
+set +x
+exit ${TRAIN_EXIT_CODE}

--- a/slurm/submit_hybrid_4node.sh
+++ b/slurm/submit_hybrid_4node.sh
@@ -1,27 +1,27 @@
 #!/bin/bash
 #SBATCH --account=healthcareeng_research
-#SBATCH --nodes=1
+#SBATCH --nodes=4
 #SBATCH --partition=batch,backfill
 #SBATCH --ntasks-per-node=8
 #SBATCH --time=04:00:00
 #SBATCH --mem=0
 #SBATCH --mail-type=FAIL
 #SBATCH --exclusive
-#SBATCH --job-name=healthcareeng_research-nvsubq.v5hybrid
+#SBATCH --job-name=healthcareeng_research-nvsubq.v5hybrid4n
 
 # Usage (from repo root):
-#   sbatch slurm/submit_hybrid.sh examples/vit5_imagenet/vit5_hybrid/full_attention.py
-#   sbatch slurm/submit_hybrid.sh examples/vit5_imagenet/vit5_hybrid/full_attention.py \
-#       net.patch_size=8 dataset.batch_size=64 train.accumulate_grad_steps=4
+#   sbatch slurm/submit_hybrid_4node.sh examples/vit5_imagenet/vit5_hybrid/full_attention.py \
+#       net.patch_size=4 dataset.batch_size=16 train.accumulate_grad_steps=4
 #
-# Via queue.sh for chaining (recommended for 800-epoch runs):
-#   bash slurm/queue.sh slurm/submit_hybrid.sh 12 \
-#       examples/vit5_imagenet/vit5_hybrid/full_attention.py
+# Patch size / batch / accum guide (4 nodes = 32 GPUs, effective batch = 2048):
+#   patch 4:  batch_size=16  accumulate_grad_steps=4
+#   patch 2:  batch_size=4   accumulate_grad_steps=16
+#   patch 1:  batch_size=1   accumulate_grad_steps=64
 
 set -x
 
 if [ -z "${1:-}" ]; then
-    echo "Usage: sbatch slurm/submit_hybrid.sh <config.py> [overrides...]"
+    echo "Usage: sbatch slurm/submit_hybrid_4node.sh <config.py> [overrides...]"
     exit 1
 fi
 

--- a/tests/modules/test_vit5_components.py
+++ b/tests/modules/test_vit5_components.py
@@ -8,7 +8,7 @@ Tests verify:
 5. ViT5ResidualBlock: residual connection, LayerScale, DropPath
 6. ViT5ClassificationNet: end-to-end forward pass, parameter count, token assembly
 7. Cross-validation against the reference ViT-5 repo
-8. GAP readout & token layout (readout / prepend_registers)
+8. GAP / CLS readout & token layout
 
 Run:
     PYTHONPATH=. python -m pytest tests/modules/test_vit5_components.py -v -o addopts=""
@@ -664,14 +664,15 @@ class TestCrossValidation:
         assert attn.reg_rope_base == 100.0
 
 
-# ─── 8. GAP readout & token layout (readout / prepend_registers) ─────────────
+# ─── 8. GAP / CLS readout & token layout ──────────────────────────────────────
 
 
 class TestGAPReadoutAndTokenLayout:
-    """Tests for global average pooling readout and register token placement.
+    """Tests for GAP / CLS readouts and register token placement.
 
-    Covers the bug where ``readout="gap"`` with ``prepend_registers=True``
-    produced incorrect token slicing, and verifies all register layout combos.
+    Token layout is fixed at ``[patches, CLS?, registers, padding?]``. These
+    tests cover readout correctness and zero-padding math for the CLS+registers
+    row.
 
     Uses ``nn.Identity`` as the sequence mixer because ``ViT5Attention`` has
     precomputed RoPE buffers sized for CLS-included sequences.  These tests
@@ -682,7 +683,6 @@ class TestGAPReadoutAndTokenLayout:
         self,
         device: torch.device,
         readout: str = "cls",
-        prepend_registers: bool = False,
         num_registers: int = 4,
         hidden_dim: int = 384,
         num_blocks: int = 1,
@@ -698,7 +698,6 @@ class TestGAPReadoutAndTokenLayout:
             num_registers=num_registers,
             dropout_rate=0.0,
             readout=readout,
-            prepend_registers=prepend_registers,
             norm_cfg=LazyConfig(RMSNorm)(dim=hidden_dim, eps=1e-6),
             block_cfg=LazyConfig(ViT5ResidualBlock)(
                 sequence_mixer_cfg=LazyConfig(nn.Identity)(),
@@ -728,26 +727,15 @@ class TestGAPReadoutAndTokenLayout:
         out = self._forward(net, device)
         assert out["logits"].shape == (2, 1000)
 
-    def test_gap_appended_registers(self, device: torch.device) -> None:
-        """GAP with appended registers (default layout) excludes register tokens."""
-        net = self._make_net(device, readout="gap", prepend_registers=False, num_registers=4)
+    def test_gap_with_registers(self, device: torch.device) -> None:
+        """GAP with registers (appended by the fixed layout) excludes them from pooling."""
+        net = self._make_net(device, readout="gap", num_registers=4)
         net.eval()
         out = self._forward(net, device)
         assert out["logits"].shape == (2, 1000)
 
-    def test_gap_no_cls_prepend_registers_flag(self, device: torch.device) -> None:
-        """Regression: ``readout="gap"`` + ``prepend_registers=True``.
-
-        Registers are always appended when CLS token is absent (the prepend
-        guard requires ``cls_token``), so the readout must slice from the end.
-        """
-        net = self._make_net(device, readout="gap", prepend_registers=True, num_registers=4)
-        net.eval()
-        out = self._forward(net, device)
-        assert out["logits"].shape == (2, 1000)
-
-    def test_gap_excludes_registers_appended(self, device: torch.device) -> None:
-        """Verify GAP actually excludes register tokens when they are appended.
+    def test_gap_excludes_registers(self, device: torch.device) -> None:
+        """Verify GAP actually excludes register tokens in the fixed ``[patches, regs]`` layout.
 
         Manually builds the ``[patches, regs]`` sequence and asserts its length
         is 200, then checks the full forward pass produces valid logits.
@@ -759,50 +747,41 @@ class TestGAPReadoutAndTokenLayout:
         inp = {"input": x, "condition": None}
 
         with torch.no_grad():
-            # Manually trace to check register exclusion
-            xr = x.permute(0, 3, 1, 2)  # [B, C, H, W]
+            xr = x.permute(0, 3, 1, 2)
             patches = net.patch_embed(xr)
-            patches = patches.flatten(2).transpose(1, 2)  # [B, 196, C]
+            patches = patches.flatten(2).transpose(1, 2)
             patches = patches + net.pos_embed
 
             reg_tokens = net.reg_token.expand(2, -1, -1)
-            seq = torch.cat([patches, reg_tokens], dim=1)  # [B, 200, C]
+            seq = torch.cat([patches, reg_tokens], dim=1)
 
-            # GAP should use only first 196 tokens
             assert seq.shape[1] == 200
             out = net(inp)
             assert out["logits"].shape == (2, 1000)
 
-    def test_cls_prepend_registers_layout(self, device: torch.device) -> None:
-        """With CLS + ``prepend_registers``, layout is ``[CLS, regs, (pad), patches]``."""
-        net = self._make_net(device, readout="cls", prepend_registers=True, num_registers=4)
-        net.eval()
-        out = self._forward(net, device)
-        assert out["logits"].shape == (2, 1000)
+    def test_cls_fewer_registers_zero_padded(self, device: torch.device) -> None:
+        """CLS + registers row creates zero-padding when not divisible by grid width.
 
-    def test_cls_prepend_fewer_registers_zero_padded(self, device: torch.device) -> None:
-        """CLS-row with fewer registers than grid width creates zero-padding.
-
-        With patch_size=16 and image_size=224, num_patches_w=14.
-        CLS-row needs 1 + regs + pad = num_patches_w, so pad = 14 - 1 - 2 = 11.
-        Total T = 14 (first row) + 196 (patches) = 210, divisible by grid_w=14.
+        Layout: ``[patches (196), CLS (1), regs (2), pad (11)]`` — 210 tokens,
+        divisible by grid_w=14.
         """
-        net = self._make_net(device, readout="cls", prepend_registers=True, num_registers=2)
+        net = self._make_net(device, readout="cls", num_registers=2)
         net.eval()
-        # Verify zero-pad buffer exists with correct size
-        assert net.reg_zero_pad is not None
-        assert net.reg_zero_pad.shape == (1, 11, 384)  # pad = 14 - 1 - 2 = 11
+        assert net._zero_pad is not None
+        assert net._zero_pad.shape == (1, 11, 384)
+        assert net._pad_size == 11
         out = self._forward(net, device)
         assert out["logits"].shape == (2, 1000)
 
-    def test_cls_prepend_full_row_no_padding(self, device: torch.device) -> None:
-        """CLS-row with num_registers = num_patches_w - 1 creates no padding."""
-        net = self._make_net(device, readout="cls", prepend_registers=True, num_registers=13)
-        assert net.reg_zero_pad is None
+    def test_cls_full_row_no_padding(self, device: torch.device) -> None:
+        """CLS + 13 registers divides evenly by grid_w=14, so no zero-padding is added."""
+        net = self._make_net(device, readout="cls", num_registers=13)
+        assert net._zero_pad is None
+        assert net._pad_size == 0
 
-    def test_cls_append_registers_layout(self, device: torch.device) -> None:
-        """With CLS + appended registers, layout is ``[CLS, patches, regs]``."""
-        net = self._make_net(device, readout="cls", prepend_registers=False, num_registers=4)
+    def test_cls_readout_layout(self, device: torch.device) -> None:
+        """CLS readout works on the fixed ``[patches, CLS, regs, pad?]`` layout."""
+        net = self._make_net(device, readout="cls", num_registers=4)
         net.eval()
         out = self._forward(net, device)
         assert out["logits"].shape == (2, 1000)
@@ -838,7 +817,6 @@ class TestRegisterConcatReadout:
         neck_compression_ratio: int = 4,
         hidden_dim: int = 384,
         num_blocks: int = 1,
-        prepend_registers: bool = True,
     ) -> ViT5ClassificationNet:
         """Build a ViT-5 net with ``register_concat`` readout using Identity mixer."""
         neck_dim = hidden_dim // neck_compression_ratio
@@ -854,7 +832,6 @@ class TestRegisterConcatReadout:
             dropout_rate=0.0,
             readout="register_concat",
             neck_compression_ratio=neck_compression_ratio,
-            prepend_registers=prepend_registers,
             norm_cfg=LazyConfig(RMSNorm)(dim=out_norm_dim, eps=1e-6),
             block_cfg=LazyConfig(ViT5ResidualBlock)(
                 sequence_mixer_cfg=LazyConfig(nn.Identity)(),
@@ -932,7 +909,6 @@ class TestRegisterConcatReadout:
             num_registers=4,
             dropout_rate=0.0,
             readout="gap",
-            prepend_registers=True,
             norm_cfg=LazyConfig(RMSNorm)(dim=384, eps=1e-6),
             block_cfg=LazyConfig(ViT5ResidualBlock)(
                 sequence_mixer_cfg=LazyConfig(nn.Identity)(),
@@ -952,16 +928,9 @@ class TestRegisterConcatReadout:
         # Different head dims so logits differ structurally
         assert net_rc.out_proj.in_features != net_gap.out_proj.in_features
 
-    def test_prepend_registers_layout(self, device: torch.device) -> None:
-        """Works correctly with prepended registers ``[regs, pad, patches]``."""
-        net = self._make_net(device, prepend_registers=True)
-        net.eval()
-        out = self._forward(net, device)
-        assert out["logits"].shape == (2, 1000)
-
-    def test_append_registers_layout(self, device: torch.device) -> None:
-        """Works correctly with appended registers ``[patches, regs]``."""
-        net = self._make_net(device, prepend_registers=False)
+    def test_registers_layout(self, device: torch.device) -> None:
+        """Works correctly on the fixed ``[patches, registers, pad?]`` layout."""
+        net = self._make_net(device)
         net.eval()
         out = self._forward(net, device)
         assert out["logits"].shape == (2, 1000)


### PR DESCRIPTION
## Summary

- Adds hybrid architecture support to `ViT5ClassificationNet`: interleave Hyena and Attention blocks via `layer_pattern` + `layer_types` (e.g. `"HHHA" * 3`).
- Standardizes token layout to `[patches, CLS, registers, padding]` across all block types. Padding is dynamically stripped for Attention blocks and kept for Hyena blocks.
- Adds `has_cls` parameter to `ViT5Attention` for conditional CLS RoPE entry, and auto-computes `register_start_idx` from the layout.
- Four new experiment configs under `examples/vit5_imagenet/vit5_hybrid/`: full attention (A×12), hybrid HA (HA×6), hybrid HHHA (HHHA×3), full Hyena (H×12). All are patch-size agnostic — override `net.patch_size` to change resolution.
- All derived values (`num_patches_h/w`, `grid_w`, `L_cache`, `qk_norm.dim`, `short_conv` channels) use `${eval:'...'}` OmegaConf interpolation referencing the top-level network config.
- Hyena blocks use learnable `GaussianModulationND` mask on the SIREN kernel output (same parametrization as v5 Gaussian configs).
- Hyena `k_norm` is automatically set to `Identity` when the gate is non-linear (SiLU), skipping the `movedim` round-trip in forward to avoid overhead.
- Improved `extra_repr` for `GaussianModulationND` (shows mask values at first step and boundary for narrowest/widest channels) and `Hyena` (shows `q_norm`/`k_norm` separately).

### FLOPs comparison (ViT-5-Small, 224×224)

| Config | Patch 16 GFLOPs | Patch 8 GFLOPs |
| ------ | --------------- | -------------- |
| Full Attention (A×12) | 9.41 | 45.16 |
| Hybrid HA (HA×6) | 9.69 | 41.94 |
| Hybrid HHHA (HHHA×3) | 9.84 | 40.33 |
| Full Hyena (H×12) | 9.98 | 38.72 |

At patch 8, Full Hyena is 14.3% cheaper than Full Attention.

## Test plan

- [x] Smoke-tested instantiation + shape assertions for both patch 16 and patch 8
- [x] Verified all `${eval:'...'}` interpolations resolve correctly after `apply_config_overrides`
- [x] Verified GaussianModulationND instantiates correctly with interpolated `data_dim` and `num_channels`
- [x] Verified Hyena `k_norm=Identity` when gate is SiLU
- [x] FLOPs computed and recorded in `TRACKER.md`
- [ ] Full training runs (tracked in `vit5_hybrid/TRACKER.md`)