### PR TITLE
fix: use global_rank for DALI shard_id in multi-node ImageNet pipeline

### DIFF
--- a/experiments/datamodules/dali_imagenet_fused.py
+++ b/experiments/datamodules/dali_imagenet_fused.py
@@ -510,9 +510,11 @@ class DALIImageNetFusedDataModule(pl.LightningDataModule):
 
         if self.trainer is not None:
             local_rank = self.trainer.local_rank
+            global_rank = self.trainer.global_rank
             world_size = self.trainer.world_size
         else:
             local_rank = int(os.environ.get("LOCAL_RANK", self.device_id))
+            global_rank = int(os.environ.get("RANK", local_rank))
             world_size = int(os.environ.get("WORLD_SIZE", 1))
 
         if stage in ("fit", None):
@@ -521,7 +523,7 @@ class DALIImageNetFusedDataModule(pl.LightningDataModule):
                 self._ra_source = _RepeatedAugSource(
                     file_root=train_root,
                     num_repeats=self._num_repeats,
-                    shard_id=local_rank,
+                    shard_id=global_rank,
                     num_shards=world_size,
                     seed=self.seed,
                 )
@@ -543,7 +545,7 @@ class DALIImageNetFusedDataModule(pl.LightningDataModule):
                 use_three_augment=self._use_three_augment,
                 color_jitter=self._color_jitter,
                 rand_augment_config=self._rand_augment_config,
-                shard_id=local_rank,
+                shard_id=global_rank,
                 num_shards=world_size,
                 batch_size=self.batch_size,
                 num_threads=self.num_workers,
@@ -563,7 +565,7 @@ class DALIImageNetFusedDataModule(pl.LightningDataModule):
                 eval_crop_ratio=self.eval_crop_ratio,
                 norm_mean=self._norm_mean_tuple,
                 norm_std=self._norm_std_tuple,
-                shard_id=local_rank,
+                shard_id=global_rank,
                 num_shards=world_size,
                 batch_size=self.batch_size,
                 num_threads=self.num_workers,


### PR DESCRIPTION
The DALI train/val pipelines were sharded by trainer.local_rank, which ranges over [0, gpus_per_node) on every node. With num_shards=world_size, this caused only the first gpus_per_node shards to ever be read in multi-node runs (e.g. 8/32 in a 4-node setup), with each read 4x redundantly across nodes. Train, val, and test all silently saw ~25% of the dataset, biasing val/acc_ema-driven checkpoint selection. Switch shard_id to trainer.global_rank; keep device_id=local_rank for the local CUDA index. Single-node behavior is unchanged since global_rank == local_rank there.

## Summary

<!-- What does this PR change and why? -->

## Environment setup

Create the conda environment (required to run tests):

```bash
bash setup_conda_env.sh
conda activate nvsubquadratic
```

## Pre-commit

Run locally before pushing (hooks also run on `git push` if installed):

```bash
pre-commit install
pre-commit install --hook-type pre-push
# Optional: run pre-push checks without pushing
pre-commit run --hook-stage pre-push --all-files
```

**Required for CI:** Keep the following line in your PR description (the PR Description Check workflow looks for it):

> Pre-commit checks passed

_(Replace with accurate wording after you run hooks; e.g. if something is intentionally skipped, coordinate with reviewers.)_

## Testing

<!-- How did you test this? -->
