### PR TITLE
feat: anisotropic kernel grids + 3D spatial_recall_v2 ablations

### DIFF
--- a/examples/spatial_recall_v2/color_conditioning_3d/hyena_gaussian_mask_aniso_grid.py
+++ b/examples/spatial_recall_v2/color_conditioning_3d/hyena_gaussian_mask_aniso_grid.py
@@ -1,0 +1,100 @@
+# TODO: Add license header here
+
+"""3D Color Conditioning -- Hyena XS with anisotropic kernel grid.
+
+Intervention isolated by this config:
+    - SIREN kernel ``L_cache = (D, H, W) = (CANVAS_DEPTH, CANVAS_SIZE, CANVAS_SIZE)``
+      i.e. per-axis kernel grid that matches the actual volume.  Each axis spans
+      the full ``[-1, 1]`` range at its own resolution; no axis-0 region is
+      wasted in the cube cache.
+    - Gaussian mask ``init_extent = (DEPTH_INIT_EXTENT, 1.0, 1.0)`` where the
+      depth scale is large enough to saturate the entire depth-axis logspace
+      ramp at ``max_std`` (depth axis is essentially **unmasked at init** —
+      every channel starts at the widest possible Gaussian on depth).  H and
+      W keep the reference ramp ``[min_std, init_std_high_unit]``.
+
+      Why the depth axis must be max-saturated: the mask's ``min_step`` is
+      driven by the densest grid axis (here grid_size=127, min_step≈0.0159
+      → min_std≈0.0075).  The depth kernel grid, in contrast, has only 15
+      points spanning ``[-1, 1]`` (physical step ≈0.143).  A channel with
+      std≈0.0075 masks the depth axis to ≈0 at the very first cell, so the
+      bottom half of any depth-axis logspace ramp anchored at min_std is
+      unusable.  Lifting the entire depth ramp to ``max_std`` removes this
+      regime mismatch — depth is left to be shaped by the (small)
+      ``L_cache_d=8`` kernel grid, which already constrains its frequency
+      content.
+    - ``omega_0 = KERNEL_OMEGA_0`` (default = 10), unchanged.
+
+Compare against:
+    - ``hyena_gaussian_mask_baseline.py``:  isotropic L_cache=64 (cube cache),
+      isotropic init_extent=1.0.  Differs from this config in **both** the
+      kernel grid and the depth-axis mask init — measures the combined
+      effect of the anisotropic-grid intervention.
+    - ``hyena_gaussian_mask_peraxis.py``:   isotropic L_cache=64,
+      ``init_extent=(0.125, 1.0, 1.0)`` (per-axis mask, narrowed depth,
+      previous ablation winner).  This config takes the opposite tack on
+      depth: the kernel grid is shrunk to size 8 on depth and the mask is
+      maximally relaxed on depth — anisotropy is moved entirely from the
+      mask to the grid.
+
+The full kernel cache for ``L_cache=(8, 64, 64)`` is
+``(1, 15, 127, 127, embedding_dim)`` instead of the cube
+``(1, 127, 127, 127, embedding_dim)`` used by the baseline — ~8.5x fewer
+SIREN forward FLOPs on the kernel grid.
+"""
+
+import math
+
+from examples.spatial_recall_v2.color_conditioning_3d._base import CANVAS_DEPTH, CANVAS_SIZE
+from examples.spatial_recall_v2.color_conditioning_3d.hyena import HIDDEN_DIM
+from examples.spatial_recall_v2.color_conditioning_3d.hyena import get_config as _get_hyena_config
+from experiments.default_cfg import ExperimentConfig
+from nvsubquadratic.lazy_config import LazyConfig
+from nvsubquadratic.modules.masks_nd import GaussianModulationND
+
+
+DATA_DIM = 3
+
+# Per-axis kernel grid: matches the (D, H, W) of the input volume so each
+# axis is sampled at its own native resolution.  With grid_type="double"
+# this produces a kernel cache of shape (1, 15, 127, 127, C).
+L_CACHE_PER_AXIS = [CANVAS_DEPTH, CANVAS_SIZE, CANVAS_SIZE]
+
+# Mask: ``init_extent`` multiplicatively scales the per-axis logspace ramp.
+# We want the entire depth-axis ramp to saturate at ``max_std``, i.e.
+# ``min_std * extent ≥ max_std``.  At our config (min_attn=0.1,
+# max_attn=0.95, grid_size=127):
+#     min_step = 2/126 ≈ 0.01587
+#     min_std  = min_step * sqrt(-1/(2 ln 0.1)) ≈ 0.0075
+#     max_std  =        1 * sqrt(-1/(2 ln 0.95)) ≈ 3.121
+#     max_std / min_std ≈ 416
+# We compute the saturation threshold symbolically so it stays correct if
+# the attenuation parameters or grid_size ever change.
+_MASK_GRID_SIZE = 2 * max(L_CACHE_PER_AXIS) - 1  # auto-injected by CKConvND
+_MIN_STEP = 2.0 / (_MASK_GRID_SIZE - 1)
+_MIN_STD = _MIN_STEP * math.sqrt(-1.0 / (2.0 * math.log(0.1)))
+_MAX_STD = 1.0 * math.sqrt(-1.0 / (2.0 * math.log(0.95)))
+DEPTH_INIT_EXTENT = _MAX_STD / _MIN_STD  # ≈ 416 → both ends clamp at max_std
+INIT_EXTENT_PER_AXIS = (DEPTH_INIT_EXTENT, 1.0, 1.0)
+
+
+def get_config() -> ExperimentConfig:
+    """Build and return the experiment configuration."""
+    config = _get_hyena_config()
+
+    # Per-axis Gaussian-mask init: depth saturates at max_std (essentially
+    # unmasked along depth at init); H and W use the reference ramp.
+    config.net.block_cfg.sequence_mixer_cfg.mixer_cfg.global_conv_cfg.mask_cfg = LazyConfig(GaussianModulationND)(
+        data_dim=DATA_DIM,
+        num_channels=HIDDEN_DIM,
+        min_attenuation_at_step=0.1,
+        max_attenuation_at_limit=0.95,
+        init_extent=INIT_EXTENT_PER_AXIS,
+        parametrization="direct",
+    )
+
+    # Anisotropic SIREN kernel grid: one extent per axis instead of the
+    # default scalar ``${dataset.canvas_size}``.
+    config.net.block_cfg.sequence_mixer_cfg.mixer_cfg.global_conv_cfg.kernel_cfg.L_cache = L_CACHE_PER_AXIS
+
+    return config

--- a/nvsubquadratic/modules/ckconv_nd.py
+++ b/nvsubquadratic/modules/ckconv_nd.py
@@ -7,12 +7,14 @@ import copy
 import inspect
 import math
 import warnings
+from collections.abc import Sequence
 from typing import Literal
 
 import torch
 from einops import rearrange
 
 from nvsubquadratic.lazy_config import LazyConfig, _resolve_target, instantiate
+from nvsubquadratic.modules.kernels_nd import _normalize_l_cache
 
 # Standard FFT convolutions
 from nvsubquadratic.ops.circular_fftconv import (
@@ -264,23 +266,41 @@ class CKConvND(torch.nn.Module):
         # When grid_type="single", grid_lens is halved relative to spatial_dims
         # (see forward()).  Adjust L_cache so the positional-embedding grid_cache
         # spans [-1, 1] for the actual kernel size instead of a truncated subrange.
-        effective_L = getattr(kernel_cfg, "L_cache", None)
-        if grid_type == "single" and effective_L is not None:
-            # Deepcopy before mutating so shared config objects aren't corrupted.
-            kernel_cfg = copy.deepcopy(kernel_cfg)
-            effective_L = (effective_L + 1) // 2
-            kernel_cfg.L_cache = effective_L
+        # ``L_cache`` may be either a scalar int (isotropic grid) or a sequence
+        # of length ``data_dim`` (anisotropic grid); both forms are supported
+        # uniformly via ``_normalize_l_cache``.
+        L_cache_raw = getattr(kernel_cfg, "L_cache", None)
+        effective_L_per_axis: tuple[int, ...] | None = None
+        if L_cache_raw is not None:
+            effective_L_per_axis = _normalize_l_cache(L_cache_raw, data_dim)
+            if grid_type == "single":
+                # Deepcopy before mutating so shared config objects aren't corrupted.
+                kernel_cfg = copy.deepcopy(kernel_cfg)
+                effective_L_per_axis = tuple((L + 1) // 2 for L in effective_L_per_axis)
+                # Pass the new L_cache back in the same form the user supplied
+                # (scalar in / scalar out, sequence in / sequence out) so config
+                # serialization round-trips cleanly.
+                if isinstance(L_cache_raw, Sequence) and not isinstance(L_cache_raw, (str, bytes)):
+                    kernel_cfg.L_cache = list(effective_L_per_axis)
+                else:
+                    # Anisotropic shrink of a scalar should never happen because
+                    # ``_normalize_l_cache(int, ...)`` broadcasts to a uniform tuple.
+                    kernel_cfg.L_cache = int(effective_L_per_axis[0])
 
         # Inject the actual kernel size into mask_cfg so that attenuation-based
         # initialization (GaussianModulationND) uses the correct grid geometry.
-        # This keeps grid_type logic in one place (here) instead of duplicating
-        # it in the mask.
-        if effective_L is not None:
+        # The mask is intentionally isotropic here (one ``grid_size`` shared
+        # across axes); we feed it the *largest* per-axis kernel size so the
+        # narrowest reachable Gaussian bandwidth (``min_std`` from
+        # ``min_attenuation_at_step``) stays achievable on the highest-resolution
+        # axis.  Per-axis bandwidth differences should be expressed via the
+        # mask's per-axis ``init_extent`` instead.
+        if effective_L_per_axis is not None:
             mask_target = _resolve_target(mask_cfg["__target__"]) if "__target__" in mask_cfg else None
             if mask_target is not None and "grid_size" in inspect.signature(mask_target).parameters:
                 # Deepcopy before mutating so shared config objects aren't corrupted.
                 mask_cfg = copy.deepcopy(mask_cfg)
-                mask_cfg.grid_size = 2 * effective_L - 1
+                mask_cfg.grid_size = 2 * max(effective_L_per_axis) - 1
 
         # Construct kernel and mask
         self.kernel = instantiate(kernel_cfg)

--- a/nvsubquadratic/modules/kernels_nd.py
+++ b/nvsubquadratic/modules/kernels_nd.py
@@ -19,6 +19,41 @@ from einops import rearrange
 from nvsubquadratic.lazy_config import LazyConfig, instantiate
 
 
+def _normalize_l_cache(L_cache: int | Sequence[int], data_dim: int) -> tuple[int, ...]:
+    """Broadcast ``L_cache`` to a per-axis tuple of positive ints (>= 2).
+
+    Accepts a single int (broadcast to all axes) or a sequence of ints of
+    length ``data_dim``.  Used by the kernel and positional-embedding
+    classes so each spatial axis can have its own grid resolution
+    (anisotropic kernel grid).  Booleans are explicitly rejected because
+    ``True``/``False`` would silently broadcast to ``(1,)*data_dim``,
+    which would then fail the lower-bound check below.
+
+    Args:
+        L_cache: Scalar cache extent or per-axis sequence.
+        data_dim: Number of spatial dimensions.
+
+    Returns:
+        Tuple of length ``data_dim`` with one positive int per axis.
+    """
+    if isinstance(L_cache, bool):
+        raise TypeError("L_cache must be an int or a sequence of ints, got bool")
+    if isinstance(L_cache, int):
+        per_axis: tuple[int, ...] = (int(L_cache),) * data_dim
+    elif isinstance(L_cache, Sequence) and not isinstance(L_cache, (str, bytes)):
+        per_axis = tuple(int(v) for v in L_cache)
+        if len(per_axis) != data_dim:
+            raise ValueError(f"L_cache sequence must have length data_dim={data_dim}, got length {len(per_axis)}")
+    else:
+        raise TypeError(f"L_cache must be an int or a sequence of ints, got {type(L_cache).__name__}")
+    for L in per_axis:
+        # L must be >= 2 because step_size = 1/(L-1) and the cache uses
+        # ``linspace(-1, 1, 2*L - 1)`` (which needs >= 3 points).
+        if L < 2:
+            raise ValueError(f"L_cache values must be >= 2, got {L}")
+    return per_axis
+
+
 class RandomFourierPositionalEmbeddingND(torch.nn.Module):
     """Implements a N-dimensional positional embedding using Random Fourier Features.
 
@@ -31,7 +66,7 @@ class RandomFourierPositionalEmbeddingND(torch.nn.Module):
         self,
         data_dim: int,
         embedding_dim: int,
-        L_cache: int,
+        L_cache: int | Sequence[int],
         omega_0: float,
         use_bias: bool = True,
     ):
@@ -40,7 +75,11 @@ class RandomFourierPositionalEmbeddingND(torch.nn.Module):
         Args:
             data_dim: Dimension of input data.
             embedding_dim: Dimensionality of the positional embedding. Must be even.
-            L_cache: Number of cached time steps for the input positions.
+            L_cache: Number of cached time steps per axis. Either a scalar int
+                (broadcast to every axis, isotropic grid) or a sequence of
+                length ``data_dim`` (one extent per spatial axis, anisotropic
+                grid).  The cached grid then has shape
+                ``(1, 2*L_0 - 1, ..., 2*L_{d-1} - 1, data_dim)``.
             omega_0: Frequency scaling factor for the Fourier features.
             use_bias: Whether to use a bias term in the linear layer.
 
@@ -53,6 +92,9 @@ class RandomFourierPositionalEmbeddingND(torch.nn.Module):
         super().__init__()
         self.data_dim = data_dim
         self.embedding_dim = embedding_dim
+        # Canonical per-axis form; ``L_cache`` is preserved as the input
+        # value for diagnostics / external read-back.
+        self.L_cache_per_axis = _normalize_l_cache(L_cache, data_dim)
         self.L_cache = L_cache
         self.omega_0 = omega_0
         self.use_bias = use_bias
@@ -66,22 +108,67 @@ class RandomFourierPositionalEmbeddingND(torch.nn.Module):
         if self.linear.bias is not None:
             torch.nn.init.constant_(self.linear.bias, 0.0)
 
-        # Construct grid cache (cube) of size 2 * L_cache - 1.
+        # Construct grid cache: per-axis ``linspace(-1, 1, 2*L - 1)`` so each
+        # axis spans its own resolution at full [-1, 1] extent.
         # TODO(@dwromero): We must make sure that the grid_cache is kept in float32.
         with torch.inference_mode(False):
             with torch.no_grad():
-                t = torch.linspace(-1, 1, 2 * self.L_cache - 1, dtype=torch.float32)
-                grid_cache = rearrange(
-                    torch.stack(torch.meshgrid(*[t] * data_dim, indexing="ij"), dim=-1), "... -> 1 ..."
-                )
+                grid_cache = self._build_grid_cache(self.L_cache_per_axis)
         self.register_buffer("grid_cache", grid_cache, persistent=False)
 
-        # Save the step size for the cache, so that subsequent calls keep equal distances between the elements of the cache grid.
-        self.step_size = 1.0 / (L_cache - 1)
+        # Per-axis step size: kept frozen at the *original* L_cache so that
+        # subsequent runtime cache extensions preserve the spacing they were
+        # built with (a longer sequence still uses the same step).
+        self.step_sizes = tuple(1.0 / (L - 1) for L in self.L_cache_per_axis)
 
         # Add ._no_weight_decay flag to all parameters to avoid weight decay
         for param in self.parameters():
             param._no_weight_decay = True
+
+    @staticmethod
+    def _build_grid_cache(
+        L_per_axis: Sequence[int],
+        max_limits: Sequence[float] | None = None,
+        device: torch.device | None = None,
+    ) -> torch.Tensor:
+        """Build the cached coordinate grid for the given per-axis lengths.
+
+        Each axis spans ``[-max_limit_i, +max_limit_i]`` sampled at
+        ``2 * L_i - 1`` points (default ``max_limit_i = 1.0`` at construction,
+        possibly larger after a runtime extension to keep step size constant).
+        """
+        if max_limits is None:
+            max_limits = (1.0,) * len(L_per_axis)
+        ts = [
+            torch.linspace(-float(m), float(m), 2 * L - 1, device=device, dtype=torch.float32)
+            for L, m in zip(L_per_axis, max_limits)
+        ]
+        return rearrange(torch.stack(torch.meshgrid(*ts, indexing="ij"), dim=-1), "... -> 1 ...")
+
+    def _maybe_extend_grid_cache(self, seq_lens: tuple[int, ...]) -> None:
+        """Grow ``grid_cache`` per axis whenever any axis exceeds its cache.
+
+        Each axis is extended independently while preserving its original
+        step size: along an extended axis the new range becomes
+        ``[-max_limit, +max_limit]`` with
+        ``max_limit = 1.0 + step_size * (seq_len - L_cache_orig)``.  Axes
+        that are not extended are rebuilt at their existing extent so the
+        cache remains a single rectangular tensor.
+        """
+        if all(L >= sl for L, sl in zip(self.L_cache_per_axis, seq_lens)):
+            return
+        new_L_per_axis = tuple(max(L, sl) for L, sl in zip(self.L_cache_per_axis, seq_lens))
+        max_limits = tuple(
+            1.0 + step * (new_L - L) for L, new_L, step in zip(self.L_cache_per_axis, new_L_per_axis, self.step_sizes)
+        )
+        with torch.inference_mode(False):
+            with torch.no_grad():
+                self.grid_cache = self._build_grid_cache(
+                    new_L_per_axis,
+                    max_limits=max_limits,
+                    device=self.grid_cache.device,
+                )
+        self.L_cache_per_axis = new_L_per_axis
 
     def forward(self, seq_lens: tuple[int, ...]) -> tuple[torch.Tensor, torch.Tensor]:
         """Computes the positional embeddings for a sequence of the given length.
@@ -103,31 +190,18 @@ class RandomFourierPositionalEmbeddingND(torch.nn.Module):
             f"seq_lens must be of length {self.data_dim}. Current length: {len(seq_lens)}"
         )
 
-        # Get the maximum sequence length.
-        seq_len = max(seq_lens)
-
-        # If the sequence is longer than the cache, create a new grid cache.
-        if self.L_cache < seq_len:
-            with torch.inference_mode(False):
-                with torch.no_grad():
-                    max_limit = 1.0 + self.step_size * (seq_len - self.L_cache)
-                    t = torch.linspace(
-                        -max_limit, max_limit, 2 * seq_len - 1, device=self.grid_cache.device, dtype=torch.float32
-                    )
-                    self.grid_cache = rearrange(
-                        torch.stack(torch.meshgrid(*[t] * self.data_dim, indexing="ij"), dim=-1), "... -> 1 ..."
-                    )
-                    self.L_cache = seq_len
+        # Per-axis cache extension: any axis whose runtime seq_len exceeds
+        # its current cache triggers a rebuild that grows that axis only.
+        self._maybe_extend_grid_cache(tuple(seq_lens))
 
         # Ensure that the cached positions tensor has the correct data type.
         assert self.grid_cache.dtype == torch.float32, (
             f"grid_cache must be float32. At lower precision, indexes will be merged together. Current dtype: {self.grid_cache.dtype}"
         )
 
-        # Calculate the offsets for the grid cache.
-        offsets = [
-            self.L_cache - seq_len for seq_len in seq_lens
-        ]  # Values from which to start indexing the grid cache.
+        # Per-axis offsets: each axis is centered, so the slice picks the
+        # central ``2 * seq_len - 1`` points of that axis's cache.
+        offsets = [L - sl for L, sl in zip(self.L_cache_per_axis, seq_lens)]
 
         # Construct slice objects to index the grid cache.
         slices = [slice(offset, offset + (seq_len * 2) - 1) for offset, seq_len in zip(offsets, seq_lens)]
@@ -163,7 +237,7 @@ class RandomFourierKernelND(torch.nn.Module):
         num_layers: int,
         embedding_dim: int,
         omega_0: float,
-        L_cache: int,
+        L_cache: int | Sequence[int],
         use_bias: bool,
         nonlinear_cfg: LazyConfig,
         init_method: (Callable[[int], Callable[[torch.Tensor], torch.Tensor]] | None) = None,
@@ -177,7 +251,12 @@ class RandomFourierKernelND(torch.nn.Module):
             num_layers: Total number of layers including the first and hidden layers (>= 2).
             embedding_dim: Dimensionality of the positional embeddings.
             omega_0: Frequency scaling factor for the positional embeddings.
-            L_cache: Number of cached time steps for the input positions.
+            L_cache: Per-axis cache extents.  Either a scalar int (broadcast
+                to every axis, isotropic grid of size ``L_cache**data_dim``)
+                or a sequence of length ``data_dim`` (anisotropic grid of
+                size ``prod(L_cache)``).  The Wang init below uses the
+                product of per-axis extents so it stays correct in both
+                cases.
             use_bias: Whether to use bias in the network and embedding layers.
             nonlinear_cfg: Configuration for the nonlinear activation function.
             init_method: Optional initialization method for the kernel network.
@@ -190,6 +269,9 @@ class RandomFourierKernelND(torch.nn.Module):
         self.num_layers = num_layers
         self.embedding_dim = embedding_dim
         self.omega_0 = omega_0
+        # Canonical per-axis form drives the Wang init below; keep the
+        # original input on ``self.L_cache`` for diagnostics.
+        self.L_cache_per_axis = _normalize_l_cache(L_cache, data_dim)
         self.L_cache = L_cache
 
         # Construct positional embedding
@@ -221,9 +303,11 @@ class RandomFourierKernelND(torch.nn.Module):
         if init_method is not None:
             init_method(out_dim)(self.out_linear.weight)
         # Add Wang initialization to the output layer (to account for the fact that the output is used as a convolutional kernel)
-        # This boils down to modulating the weight of the output layer by the expected kernel size.
+        # This boils down to modulating the weight of the output layer by the expected kernel size, which is the
+        # product of the per-axis cache extents (degenerates to ``L_cache**data_dim`` for an isotropic grid).
         with torch.no_grad():
-            self.out_linear.weight.data *= math.sqrt(1.0 / (L_cache**data_dim))
+            kernel_volume = math.prod(self.L_cache_per_axis)
+            self.out_linear.weight.data *= math.sqrt(1.0 / kernel_volume)
 
     def forward(self, seq_lens: tuple[int, ...], conditioning: torch.Tensor | None = None) -> torch.Tensor:
         """Computes the random Fourier kernel for a given grid of spatial dimensions.
@@ -286,7 +370,7 @@ class SIRENPositionalEmbeddingND(torch.nn.Module):
         self,
         data_dim: int,
         embedding_dim: int,
-        L_cache: int,
+        L_cache: int | Sequence[int],
         omega_0: float,
         use_bias: bool = True,
     ):
@@ -295,13 +379,21 @@ class SIRENPositionalEmbeddingND(torch.nn.Module):
         Args:
             data_dim: Dimension of input data.
             embedding_dim: Dimensionality of the positional embedding.
-            L_cache: Number of cached time steps for the input positions.
+            L_cache: Per-axis cache extents.  Either a scalar int (broadcast
+                to every axis, isotropic grid) or a sequence of length
+                ``data_dim`` (one extent per spatial axis, anisotropic grid).
+                The cached grid then has shape
+                ``(1, 2*L_0 - 1, ..., 2*L_{d-1} - 1, data_dim)`` and each axis
+                spans ``[-1, 1]`` at its own resolution.
             omega_0: Frequency scaling factor for the Fourier features.
             use_bias: Whether to use a bias term in the linear layer.
         """
         super().__init__()
         self.data_dim = data_dim
         self.embedding_dim = embedding_dim
+        # Canonical per-axis form; ``self.L_cache`` retains the input value
+        # so external callers (e.g. CKConv) can read back what was passed.
+        self.L_cache_per_axis = _normalize_l_cache(L_cache, data_dim)
         self.L_cache = L_cache
         self.omega_0 = omega_0
         self.use_bias = use_bias
@@ -312,21 +404,66 @@ class SIRENPositionalEmbeddingND(torch.nn.Module):
         # Initialize linear projection following SIREN initialization.
         _init_siren_weights(self.linear, is_first_layer=True, w0=self.omega_0)
 
-        # Construct grid cache (cube) of size 2 * L_cache - 1.
+        # Construct grid cache: per-axis ``linspace(-1, 1, 2*L_i - 1)`` so that
+        # every axis spans the full [-1, 1] range at its own resolution.
         with torch.inference_mode(False):
             with torch.no_grad():
-                t = torch.linspace(-1, 1, 2 * self.L_cache - 1, dtype=torch.float32)
-                grid_cache = rearrange(
-                    torch.stack(torch.meshgrid(*[t] * data_dim, indexing="ij"), dim=-1), "... -> 1 ..."
-                )
+                grid_cache = self._build_grid_cache(self.L_cache_per_axis)
         self.register_buffer("grid_cache", grid_cache, persistent=False)
 
-        # Save the step size for the cache, so that subsequent calls keep equal distances between the elements of the cache grid.
-        self.step_size = 1.0 / (L_cache - 1)
+        # Per-axis step size: kept frozen at the *original* L_cache so a
+        # later runtime extension preserves the spacing it was built with.
+        self.step_sizes = tuple(1.0 / (L - 1) for L in self.L_cache_per_axis)
 
         # Add ._no_weight_decay flag to all parameters to avoid weight decay
         for param in self.parameters():
             param._no_weight_decay = True
+
+    @staticmethod
+    def _build_grid_cache(
+        L_per_axis: Sequence[int],
+        max_limits: Sequence[float] | None = None,
+        device: torch.device | None = None,
+    ) -> torch.Tensor:
+        """Build the cached coordinate grid for the given per-axis lengths.
+
+        Each axis spans ``[-max_limit_i, +max_limit_i]`` sampled at
+        ``2 * L_i - 1`` points.  At construction every ``max_limit_i`` is
+        ``1.0``; runtime extensions can pass per-axis values larger than 1
+        to preserve the original step size on extended axes.
+        """
+        if max_limits is None:
+            max_limits = (1.0,) * len(L_per_axis)
+        ts = [
+            torch.linspace(-float(m), float(m), 2 * L - 1, device=device, dtype=torch.float32)
+            for L, m in zip(L_per_axis, max_limits)
+        ]
+        return rearrange(torch.stack(torch.meshgrid(*ts, indexing="ij"), dim=-1), "... -> 1 ...")
+
+    def _maybe_extend_grid_cache(self, seq_lens: tuple[int, ...]) -> None:
+        """Grow ``grid_cache`` per axis whenever any axis exceeds its cache.
+
+        Each axis is extended independently while preserving its original
+        step size: along an extended axis the new range becomes
+        ``[-max_limit, +max_limit]`` with
+        ``max_limit = 1.0 + step_size * (seq_len - L_cache_orig)``.  Axes
+        that already cover their requested ``seq_len`` are rebuilt at their
+        existing extent so the cache stays a single rectangular tensor.
+        """
+        if all(L >= sl for L, sl in zip(self.L_cache_per_axis, seq_lens)):
+            return
+        new_L_per_axis = tuple(max(L, sl) for L, sl in zip(self.L_cache_per_axis, seq_lens))
+        max_limits = tuple(
+            1.0 + step * (new_L - L) for L, new_L, step in zip(self.L_cache_per_axis, new_L_per_axis, self.step_sizes)
+        )
+        with torch.inference_mode(False):
+            with torch.no_grad():
+                self.grid_cache = self._build_grid_cache(
+                    new_L_per_axis,
+                    max_limits=max_limits,
+                    device=self.grid_cache.device,
+                )
+        self.L_cache_per_axis = new_L_per_axis
 
     def forward(self, seq_lens: tuple[int, ...]) -> tuple[torch.Tensor, torch.Tensor]:
         """Computes the positional embeddings for a sequence of the given length.
@@ -348,32 +485,18 @@ class SIRENPositionalEmbeddingND(torch.nn.Module):
             f"seq_lens must be of length {self.data_dim}. Current length: {len(seq_lens)}"
         )
 
-        # Get the maximum sequence length.
-        seq_len = max(seq_lens)
-
-        # If the sequence is longer than the cache, create a new grid cache.
-        if self.L_cache < seq_len:
-            with torch.inference_mode(False):
-                with torch.no_grad():
-                    max_limit = 1.0 + self.step_size * (seq_len - self.L_cache)
-                    t = torch.linspace(
-                        -max_limit, max_limit, 2 * seq_len - 1, device=self.grid_cache.device, dtype=torch.float32
-                    )
-
-                    self.grid_cache = rearrange(
-                        torch.stack(torch.meshgrid(*[t] * self.data_dim, indexing="ij"), dim=-1), "... -> 1 ..."
-                    )
-                    self.L_cache = seq_len
+        # Per-axis cache extension: any axis whose runtime seq_len exceeds
+        # its current cache triggers a rebuild that grows that axis only.
+        self._maybe_extend_grid_cache(tuple(seq_lens))
 
         # Ensure that the cached positions tensor has the correct data type.
         assert self.grid_cache.dtype == torch.float32, (
             f"grid_cache must be float32. At lower precision, indexes will be merged together. Current dtype: {self.grid_cache.dtype}"
         )
 
-        # Calculate the offsets for the grid cache.
-        offsets = [
-            self.L_cache - seq_len for seq_len in seq_lens
-        ]  # Values from which to start indexing the grid cache.
+        # Per-axis offsets: each axis is centered, so the slice picks the
+        # central ``2 * seq_len - 1`` points of that axis's cache.
+        offsets = [L - sl for L, sl in zip(self.L_cache_per_axis, seq_lens)]
 
         # Construct slice objects to index the grid cache.
         slices = [slice(offset, offset + (seq_len * 2) - 1) for offset, seq_len in zip(offsets, seq_lens)]
@@ -429,7 +552,7 @@ class SIRENKernelND(torch.nn.Module):
         num_layers: int,
         embedding_dim: int,
         omega_0: float,
-        L_cache: int,
+        L_cache: int | Sequence[int],
         use_bias: bool,
         hidden_omega_0: float = 1.0,
         film_cfg: LazyConfig | None = None,
@@ -452,6 +575,9 @@ class SIRENKernelND(torch.nn.Module):
         self.embedding_dim = embedding_dim
         self.omega_0 = float(omega_0)
         self.hidden_omega_0 = float(hidden_omega_0)
+        # Canonical per-axis form drives the Wang init below; ``self.L_cache``
+        # retains the input value for diagnostics / external callers.
+        self.L_cache_per_axis = _normalize_l_cache(L_cache, data_dim)
         self.L_cache = L_cache
 
         # Construct positional embedding
@@ -481,9 +607,12 @@ class SIRENKernelND(torch.nn.Module):
         for linear in self.hidden_linears:
             _init_siren_weights(linear, is_first_layer=False, w0=self.hidden_omega_0)
         _init_siren_weights(self.out_linear, is_first_layer=False, w0=self.hidden_omega_0)
-        # Add Wang initialization to the output layer (to account for the fact that the output is used as a convolutional kernel)
+        # Add Wang initialization to the output layer (to account for the fact that the output is used as a
+        # convolutional kernel).  The expected kernel size is the *product* of per-axis cache extents, which
+        # collapses to ``L_cache**data_dim`` for an isotropic grid and stays correct for anisotropic ones.
         with torch.no_grad():
-            self.out_linear.weight.data *= math.sqrt(1.0 / (L_cache**data_dim))  # Modulation by expected kernel size.
+            kernel_volume = math.prod(self.L_cache_per_axis)
+            self.out_linear.weight.data *= math.sqrt(1.0 / kernel_volume)
 
         # Add ._no_weight_decay flag to all parameters to avoid weight decay (except for self.out_linear weights)
         # Note that the positional embedding is already excluded from weight decay by the _no_weight_decay flag.
@@ -716,7 +845,7 @@ class MultiOmegaSIRENPositionalEmbeddingND(SIRENPositionalEmbeddingND):
         self,
         data_dim: int,
         embedding_dim: int,
-        L_cache: int,
+        L_cache: int | Sequence[int],
         omega_0_per_row: Sequence[float] | torch.Tensor,
         use_bias: bool = True,
     ):
@@ -785,7 +914,7 @@ class MultiOmegaSIRENKernelND(SIRENKernelND):
         num_layers: int,
         embedding_dim: int,
         omega_0_per_row: Sequence[float] | torch.Tensor,
-        L_cache: int,
+        L_cache: int | Sequence[int],
         use_bias: bool,
         hidden_omega_0: float = 1.0,
         film_cfg: LazyConfig | None = None,
@@ -901,7 +1030,7 @@ class BlockDiagonalMultiOmegaSIRENKernelND(MultiOmegaSIRENKernelND):
         mlp_hidden_dim: int,
         num_layers: int,
         embedding_dim: int,
-        L_cache: int,
+        L_cache: int | Sequence[int],
         use_bias: bool,
         num_blocks: int = 8,
         omega_0_min: float = 1.0,
@@ -1084,7 +1213,7 @@ class LearnableOmegaSIRENPositionalEmbeddingND(SIRENPositionalEmbeddingND):
         self,
         data_dim: int,
         embedding_dim: int,
-        L_cache: int,
+        L_cache: int | Sequence[int],
         omega_0: float,
         omega_0_scale_init: float | Sequence[float] | torch.Tensor = 1.0,
         omega_0_scale_min: float = 1e-2,
@@ -1198,27 +1327,16 @@ class LearnableOmegaSIRENPositionalEmbeddingND(SIRENPositionalEmbeddingND):
             f"seq_lens must be of length {self.data_dim}. Current length: {len(seq_lens)}"
         )
 
-        # Re-build the cached coordinate grid if the requested sequence is longer
-        # than the cache (mirrors the parent's behaviour exactly).
-        seq_len = max(seq_lens)
-        if self.L_cache < seq_len:
-            with torch.inference_mode(False):
-                with torch.no_grad():
-                    max_limit = 1.0 + self.step_size * (seq_len - self.L_cache)
-                    t = torch.linspace(
-                        -max_limit, max_limit, 2 * seq_len - 1, device=self.grid_cache.device, dtype=torch.float32
-                    )
-                    self.grid_cache = rearrange(
-                        torch.stack(torch.meshgrid(*[t] * self.data_dim, indexing="ij"), dim=-1), "... -> 1 ..."
-                    )
-                    self.L_cache = seq_len
+        # Per-axis cache extension: shared with the parent, grows each axis
+        # independently while preserving its original step size.
+        self._maybe_extend_grid_cache(tuple(seq_lens))
 
         assert self.grid_cache.dtype == torch.float32, (
             f"grid_cache must be float32 (got {self.grid_cache.dtype}) — see the parent class for the rationale."
         )
 
         # Slice the cached grid to the requested per-axis lengths.
-        offsets = [self.L_cache - sl for sl in seq_lens]
+        offsets = [L - sl for L, sl in zip(self.L_cache_per_axis, seq_lens)]
         slices = [slice(off, off + (sl * 2) - 1) for off, sl in zip(offsets, seq_lens)]
         grid = self.grid_cache[:, *slices]  # type: ignore
 
@@ -1298,7 +1416,7 @@ class LearnableOmegaSIRENKernelND(SIRENKernelND):
         num_layers: int,
         embedding_dim: int,
         omega_0: float,
-        L_cache: int,
+        L_cache: int | Sequence[int],
         use_bias: bool,
         omega_0_scale_init: float | Sequence[float] | torch.Tensor = 1.0,
         omega_0_scale_min: float = 1e-2,
@@ -1413,7 +1531,7 @@ class BlockDiagonalLearnableOmegaSIRENKernelND(LearnableOmegaSIRENKernelND):
         mlp_hidden_dim: int,
         num_layers: int,
         embedding_dim: int,
-        L_cache: int,
+        L_cache: int | Sequence[int],
         use_bias: bool,
         num_blocks: int = 8,
         omega_0_min: float = 1.0,
@@ -1621,3 +1739,35 @@ if __name__ == "__main__":
                 block = w[i * rows_per_block : (i + 1) * rows_per_block, j * rows_per_block : (j + 1) * rows_per_block]
                 assert block.abs().max().item() == 0.0, f"off-block ({i},{j}) nonzero with off_block_scale=0"
     print("BlockDiag SIREN off=0.0 strictly block-diagonal: OK")
+
+    # --- Anisotropic L_cache sanity checks (per-axis kernel grid) ---
+    # 3D SIREN kernel with grid (8, 64, 64) → cache shape (1, 15, 127, 127, 16)
+    aniso_kernel = SIRENKernelND(
+        out_dim=4,
+        data_dim=3,
+        mlp_hidden_dim=8,
+        num_layers=2,
+        embedding_dim=8,
+        omega_0=10.0,
+        L_cache=(8, 64, 64),
+        use_bias=True,
+    )
+    aniso_out, aniso_grid = aniso_kernel(seq_lens=(8, 64, 64))
+    assert aniso_out.shape == (1, 15, 127, 127, 4), aniso_out.shape
+    assert aniso_grid.shape == (1, 15, 127, 127, 3), aniso_grid.shape
+    print("Anisotropic SIREN kernel L_cache=(8,64,64): kernel shape", aniso_out.shape)
+
+    # Slicing for a smaller seq_lens uses the per-axis cached extents.
+    aniso_small_out, aniso_small_grid = aniso_kernel(seq_lens=(4, 32, 32))
+    assert aniso_small_out.shape == (1, 7, 63, 63, 4), aniso_small_out.shape
+    print("Anisotropic SIREN kernel sliced for (4,32,32): kernel shape", aniso_small_out.shape)
+
+    # Per-axis cache extension grows only the axis that needs growing.
+    aniso_kernel(seq_lens=(16, 64, 64))
+    assert aniso_kernel.positional_embedding.L_cache_per_axis == (16, 64, 64), (
+        aniso_kernel.positional_embedding.L_cache_per_axis
+    )
+    print(
+        "Anisotropic SIREN kernel after seq_lens=(16,64,64): L_cache_per_axis =",
+        aniso_kernel.positional_embedding.L_cache_per_axis,
+    )

--- a/nvsubquadratic/modules/masks_nd.py
+++ b/nvsubquadratic/modules/masks_nd.py
@@ -17,12 +17,20 @@ from einops import rearrange
 
 
 def _normalize_init_extent(init_extent: float | Sequence[float] | None, data_dim: int) -> tuple[float, ...]:
-    """Broadcast ``init_extent`` to a per-axis tuple of floats in (0, 1].
+    """Broadcast ``init_extent`` to a per-axis tuple of strictly-positive floats.
 
     Accepts a single float (broadcast to all axes) or a sequence of length
     ``data_dim``.  ``None`` is treated as ``1.0`` on every axis.  Used by
     :class:`GaussianModulationND` so each spatial axis can be initialized
-    with its own bandwidth.
+    with its own bandwidth scale.
+
+    Values must be ``> 0``.  Values ``> 1`` are allowed and useful on short
+    anisotropic axes: ``init_extent`` multiplicatively scales **both** ends
+    of the per-axis logspace ramp, so a large ``init_extent`` on a short
+    axis pushes even the narrowest channel up to a usable bandwidth on that
+    axis.  The clamp ``[min_std, max_std]`` enforces feasibility, so very
+    large values simply saturate the entire ramp at ``max_std`` (= "this
+    axis is essentially unmasked at init").
     """
     if init_extent is None:
         init_extent = 1.0
@@ -37,8 +45,8 @@ def _normalize_init_extent(init_extent: float | Sequence[float] | None, data_dim
     else:
         raise TypeError(f"init_extent must be a float or a sequence of floats, got {type(init_extent).__name__}")
     for ext in extents:
-        if not 0.0 < ext <= 1.0:
-            raise ValueError(f"init_extent values must be in (0, 1], got {ext}")
+        if not ext > 0.0 or not math.isfinite(ext):
+            raise ValueError(f"init_extent values must be finite and > 0, got {ext}")
     return extents
 
 
@@ -151,27 +159,46 @@ class GaussianModulationND(torch.nn.Module):
     **Initialization** — pass ``min_attenuation_at_step`` and
     ``max_attenuation_at_limit`` (plus ``grid_size``, auto-injected by
     CKConvND).  These define the **clamp bounds** — the narrowest any
-    channel can get (min_std) and the widest (max_std).  Optionally pass
-    ``init_extent`` to control how global the widest channel is at
-    initialization, **per axis**.
+    channel can get (``min_std``) and the widest (``max_std``).  Optionally
+    pass ``init_extent`` to control the initial bandwidth scale **per
+    axis**.
 
-    All attenuation values are **single-axis** (1D) measurements.  Since the
-    mask is a product of per-dimension Gaussians, the 2D corner value is
-    ``attenuation ** 2``, and the 3D corner is ``attenuation ** 3``, etc.
+    All attenuation values are **single-axis** (1D) measurements.  Since
+    the mask is a product of per-dimension Gaussians, the 2D corner value
+    is ``attenuation ** 2``, and the 3D corner is ``attenuation ** 3``,
+    etc.
 
     - ``min_attenuation_at_step`` — 1D mask value at the first grid step
       from center for the narrowest *possible* channel.  Sets ``min_std``
-      and ``init_std_low`` (narrowest channel starts at the clamp bound).
+      and the **reference** ``init_std_low`` (narrowest channel starts at
+      the clamp bound when ``init_extent = 1``).
     - ``max_attenuation_at_limit`` — 1D mask value at the grid boundary
       (position 1) for the widest *possible* channel.  Sets ``max_std``.
-    - ``init_extent`` — grid position at which the widest *initial* channel
-      reaches 0.1 (10% mask value) along a single axis.  Controls
-      ``init_std_high`` **per axis**.  Pass a float (e.g. ``1.0``) to init
-      every axis identically, or a sequence of length ``data_dim`` to
-      choose a different bandwidth per axis (e.g. ``(1.0, 0.25, 0.25)`` on
-      an ``8x64x64`` grid starts with global reach along depth but much
-      more local reach along height and width).  Values must lie in
-      ``(0, 1]``; defaults to ``1.0`` on every axis.
+    - ``init_extent`` — per-axis bandwidth scale that multiplicatively
+      scales **both** ends of the per-axis logspace ramp:
+      ``init_std_low[d]  = clamp(min_std            * extent[d], min_std, max_std)``
+      ``init_std_high[d] = clamp(init_std_high_unit * extent[d], min_std, max_std)``
+      where ``init_std_high_unit ≈ 0.4724`` is the std at which a 1D
+      Gaussian reaches ``0.1`` at position 1.  Pass a float (broadcast to
+      all axes) or a sequence of length ``data_dim``.  Values must be
+      strictly ``> 0``; defaults to ``1.0`` on every axis (recovers the
+      reference ramp ``[min_std, init_std_high_unit]``).
+
+      Examples on an anisotropic ``L_cache=(8, 64, 64)`` cube cache
+      (mask grid_size = 127):
+
+      * ``init_extent = 1.0`` — all axes use the reference ramp from
+        ``min_std ≈ 0.0075`` to ``init_std_high ≈ 0.4724``.  On the
+        depth axis the bottom of the ramp is unusably narrow (mask ≈ 0
+        across depth for early channels).
+      * ``init_extent = (1.0, 0.25, 0.25)`` — depth uses the reference
+        ramp; H/W are 4× narrower at both ends (extreme localization).
+      * ``init_extent = (max_std/min_std, 1.0, 1.0)`` (≈ ``(416, 1, 1)``
+        at defaults) — depth ramp saturates at ``max_std`` end-to-end;
+        every depth channel is initialised at the widest possible
+        Gaussian, i.e. depth axis is essentially unmasked at init.
+        Useful when ``L_cache_d`` is short and depth-axis frequency
+        content is naturally bounded by the small kernel grid.
 
     Only **initialization** is per-axis — ``min_std`` and ``max_std``
     (clamp bounds) remain scalar and shared across axes.
@@ -180,12 +207,12 @@ class GaussianModulationND(torch.nn.Module):
         data_dim: Number of spatial/temporal dimensions.
         num_channels: Number of feature channels to modulate.
         min_attenuation_at_step: 1D mask value at first grid step (sets clamp
-            lower bound and init lower bound).
+            lower bound and the reference init lower bound).
         max_attenuation_at_limit: 1D mask value at grid boundary (sets clamp
             upper bound).
         init_extent: Scalar or per-axis sequence controlling the initial
-            bandwidth of the widest channel on each axis. Default ``1.0``
-            everywhere (start at max_std on every axis).
+            bandwidth scale on each axis.  Strictly ``> 0``; default
+            ``1.0`` (reference ramp on every axis).
         grid_size: Kernel grid points per dimension.  Auto-injected by CKConvND.
         parametrization: ``'log'``, ``'softplus'``, or ``'direct'``.
     """
@@ -215,28 +242,35 @@ class GaussianModulationND(torch.nn.Module):
         min_step = 2.0 / (grid_size - 1)
         min_std = _std_from_attenuation(min_attenuation_at_step, min_step, 1)
         max_std = _std_from_attenuation(max_attenuation_at_limit, 1.0, 1)
-        init_std_low = min_std
 
-        # init_extent is per-axis so the user can pick a different init
-        # bandwidth on each spatial axis (e.g. a short/tall axis on an
-        # anisotropic grid).  The resulting init_std_high is what each
-        # axis' logspace ramps up to; init_std_low stays shared.
+        # ``init_extent`` is a per-axis multiplicative scale on the entire
+        # logspace ramp.  Reference ramp (extent=1) goes from ``min_std`` up
+        # to ``init_std_high_unit`` (= the std at which a 1D Gaussian hits
+        # 0.1 at position 1).  Scaling both ends lets a short anisotropic
+        # axis lift its narrowest channel out of the "mask ≈ 0 everywhere"
+        # regime that a shared low end would otherwise impose.
         self.init_extent = _normalize_init_extent(init_extent, data_dim)
         _INIT_EXTENT_ATTENUATION = 0.1
+        init_std_high_unit = _std_from_attenuation(_INIT_EXTENT_ATTENUATION, 1.0, 1)
+        # Per-axis (low, high) endpoints of the logspace ramp, clamped to
+        # the feasible band.  When extent[d] is large, both endpoints
+        # saturate at max_std and the ramp collapses to a constant
+        # max_std on that axis (axis effectively unmasked at init).
+        init_std_low_per_axis = [min(max(min_std * extent, min_std), max_std) for extent in self.init_extent]
         init_std_high_per_axis = [
-            _std_from_attenuation(_INIT_EXTENT_ATTENUATION, extent, 1) for extent in self.init_extent
+            min(max(init_std_high_unit * extent, min_std), max_std) for extent in self.init_extent
         ]
 
         self.min_std = float(min_std)
         self.max_std = float(max_std)
         self._min_step = float(min_step)
 
-        # One logspace ramp per axis: every axis shares init_std_low but
-        # ends at its own init_std_high.  Result shape [data_dim, num_channels].
+        # One logspace ramp per axis with its own (low, high) endpoints.
+        # Result shape [data_dim, num_channels].
         init_std = torch.stack(
             [
-                torch.logspace(math.log10(init_std_low), math.log10(high), num_channels)
-                for high in init_std_high_per_axis
+                torch.logspace(math.log10(low), math.log10(high), num_channels)
+                for low, high in zip(init_std_low_per_axis, init_std_high_per_axis)
             ],
             dim=0,
         )
@@ -294,19 +328,24 @@ class GaussianModulationND(torch.nn.Module):
     def extra_repr(self):
         """Additional printing for the GaussianModulationND class."""
         std = self._compute_std().detach()  # [data_dim, num_channels]
-        narrowest = std.min().item()
-        widest = std.max().item()
         step = self._min_step
-        extent_str = ", ".join(f"{e:.3f}" for e in self.init_extent)
+        extent_str = ", ".join(f"{e:.3g}" for e in self.init_extent)
+        per_axis_lines = []
+        for axis in range(self.data_dim):
+            row = std[axis]
+            lo = row.min().item()
+            hi = row.max().item()
+            per_axis_lines.append(
+                f"  axis {axis}: extent={self.init_extent[axis]:.3g}, "
+                f"std∈[{lo:.4f}, {hi:.4f}], "
+                f"narrow ch mask@step={self._mask_value(lo, step):.4f}, "
+                f"wide ch mask@boundary={self._mask_value(hi, 1.0):.4f}"
+            )
         return (
             f"data_dim={self.data_dim}, num_channels={self.num_channels}, "
             f"parametrization='{self.parametrization}'\n"
-            f"  narrowest ch: mask@step={self._mask_value(narrowest, step):.4f}, "
-            f"mask@boundary={self._mask_value(narrowest, 1.0):.4f} (std={narrowest:.4f})\n"
-            f"  widest ch:    mask@step={self._mask_value(widest, step):.4f}, "
-            f"mask@boundary={self._mask_value(widest, 1.0):.4f} (std={widest:.4f})\n"
-            f"  std bounds: [{self.min_std:.4f}, {self.max_std:.4f}]\n"
-            f"  init_extent (per axis): ({extent_str})"
+            f"  std clamp bounds: [{self.min_std:.4f}, {self.max_std:.4f}]\n"
+            f"  init_extent (per axis): ({extent_str})\n" + "\n".join(per_axis_lines)
         )
 
     def forward(self, grid: torch.Tensor, x: torch.Tensor) -> torch.Tensor:

--- a/tests/modules/test_kernels_nd.py
+++ b/tests/modules/test_kernels_nd.py
@@ -1,0 +1,453 @@
+# TODO: Add license header here
+
+
+"""Tests for anisotropic kernel grids in ``nvsubquadratic.modules.kernels_nd``.
+
+These tests cover the per-axis ``L_cache`` support added to the SIREN and
+Random Fourier kernel families, plus the CKConvND plumbing that injects
+``L_cache`` and ``grid_size`` into the kernel and mask configs.
+
+Covers:
+    - ``_normalize_l_cache``: scalar broadcast, sequence pass-through,
+      validation errors (length, lower bound, type).
+    - ``SIRENPositionalEmbeddingND`` / ``RandomFourierPositionalEmbeddingND``:
+      anisotropic grid_cache shape, scalar/sequence init equivalence,
+      per-axis runtime cache extension preserves step size, sub-cache
+      slicing centers correctly along each axis.
+    - ``SIRENKernelND`` / ``RandomFourierKernelND``: kernel shape on
+      anisotropic grids, Wang init scaling uses ``prod(L_per_axis)``
+      (not ``L**data_dim``), gradient flow.
+    - Subclasses (``MultiOmegaSIRENKernelND``, learnable-ω variants):
+      sequence ``L_cache`` flows through.
+    - ``CKConvND``: scalar and sequence ``L_cache`` both reach the kernel
+      and mask correctly under ``grid_type='single'`` and ``'double'``.
+
+Usage (CPU only):
+    PYTHONPATH=. conda run -n nv-subq python -m pytest \\
+        tests/modules/test_kernels_nd.py -v -o addopts=""
+"""
+
+import math
+
+import pytest
+import torch
+
+from nvsubquadratic.lazy_config import LazyConfig
+from nvsubquadratic.modules.ckconv_nd import CKConvND
+from nvsubquadratic.modules.kernels_nd import (
+    BlockDiagonalLearnableOmegaSIRENKernelND,
+    BlockDiagonalMultiOmegaSIRENKernelND,
+    LearnableOmegaSIRENKernelND,
+    MultiOmegaSIRENKernelND,
+    RandomFourierKernelND,
+    RandomFourierPositionalEmbeddingND,
+    SIRENKernelND,
+    SIRENPositionalEmbeddingND,
+    _normalize_l_cache,
+)
+from nvsubquadratic.modules.masks_nd import GaussianModulationND
+
+
+# ---------------------------------------------------------------------------
+# _normalize_l_cache
+# ---------------------------------------------------------------------------
+
+
+class TestNormalizeLCache:
+    def test_scalar_broadcasts(self):
+        assert _normalize_l_cache(8, 1) == (8,)
+        assert _normalize_l_cache(8, 3) == (8, 8, 8)
+
+    def test_tuple_passes_through(self):
+        assert _normalize_l_cache((8, 64, 64), 3) == (8, 64, 64)
+
+    def test_list_passes_through(self):
+        assert _normalize_l_cache([8, 16], 2) == (8, 16)
+
+    def test_wrong_length_raises(self):
+        with pytest.raises(ValueError, match="length"):
+            _normalize_l_cache((8, 64), 3)
+
+    def test_too_small_raises(self):
+        with pytest.raises(ValueError, match=">= 2"):
+            _normalize_l_cache(1, 3)
+        with pytest.raises(ValueError, match=">= 2"):
+            _normalize_l_cache((8, 1, 16), 3)
+
+    def test_bool_rejected(self):
+        with pytest.raises(TypeError, match="bool"):
+            _normalize_l_cache(True, 3)
+
+    def test_str_rejected(self):
+        with pytest.raises(TypeError, match=r"L_cache must be"):
+            _normalize_l_cache("64", 3)
+
+
+# ---------------------------------------------------------------------------
+# SIRENPositionalEmbeddingND — per-axis L_cache
+# ---------------------------------------------------------------------------
+
+
+class TestSIRENPosEmbAnisotropic:
+    def test_anisotropic_grid_cache_shape(self):
+        emb = SIRENPositionalEmbeddingND(data_dim=3, embedding_dim=4, L_cache=(8, 32, 64), omega_0=1.0)
+        # cache shape is (1, 2*L_0 - 1, 2*L_1 - 1, 2*L_2 - 1, data_dim)
+        assert emb.grid_cache.shape == (1, 15, 63, 127, 3)
+        assert emb.L_cache_per_axis == (8, 32, 64)
+
+    def test_anisotropic_forward_full_resolution(self):
+        emb = SIRENPositionalEmbeddingND(data_dim=3, embedding_dim=4, L_cache=(8, 32, 64), omega_0=1.0)
+        out, grid = emb(seq_lens=(8, 32, 64))
+        assert out.shape == (1, 15, 63, 127, 4)
+        assert grid.shape == (1, 15, 63, 127, 3)
+
+    def test_anisotropic_forward_subgrid_slice(self):
+        # Smaller seq_lens than L_cache_per_axis → centered slice on each axis.
+        emb = SIRENPositionalEmbeddingND(data_dim=2, embedding_dim=4, L_cache=(8, 16), omega_0=1.0)
+        _, grid = emb(seq_lens=(4, 8))
+        assert grid.shape == (1, 7, 15, 2)
+        # Center coordinate must be 0 along every axis (cache is centered).
+        center = grid[0, 3, 7]
+        torch.testing.assert_close(center, torch.zeros(2, dtype=center.dtype))
+
+    def test_scalar_and_uniform_sequence_are_equivalent(self):
+        # L_cache=8 should produce the same cache as L_cache=(8, 8, 8).
+        torch.manual_seed(0)
+        emb_scalar = SIRENPositionalEmbeddingND(data_dim=3, embedding_dim=4, L_cache=8, omega_0=1.0)
+        torch.manual_seed(0)
+        emb_seq = SIRENPositionalEmbeddingND(data_dim=3, embedding_dim=4, L_cache=(8, 8, 8), omega_0=1.0)
+        torch.testing.assert_close(emb_scalar.grid_cache, emb_seq.grid_cache)
+        torch.testing.assert_close(emb_scalar.linear.weight, emb_seq.linear.weight)
+        assert emb_scalar.L_cache_per_axis == emb_seq.L_cache_per_axis == (8, 8, 8)
+
+    def test_per_axis_cache_extension_preserves_step(self):
+        # Build with L_cache=(8, 16); call with seq_lens=(12, 16) to grow only axis 0.
+        emb = SIRENPositionalEmbeddingND(data_dim=2, embedding_dim=2, L_cache=(8, 16), omega_0=1.0)
+        original_step_axis_0 = emb.step_sizes[0]  # 1/(8-1) = 1/7
+        _, grid = emb(seq_lens=(12, 16))
+        # Axis 1 unchanged; axis 0 grew to 12.
+        assert emb.L_cache_per_axis == (12, 16)
+        # Slice covers seq_lens=(12, 16) → grid shape (1, 23, 31, 2).
+        assert grid.shape == (1, 23, 31, 2)
+        # Step size along axis 0 must equal the *original* (1/7), not the
+        # naive new spacing 2/(2*12-2)=1/11.
+        actual_step_axis_0 = float(grid[0, 1, 0, 0] - grid[0, 0, 0, 0])
+        torch.testing.assert_close(
+            torch.tensor(actual_step_axis_0),
+            torch.tensor(original_step_axis_0),
+            rtol=1e-5,
+            atol=1e-6,
+        )
+        # Step size along axis 1 must still be 1/(16-1)=1/15.
+        actual_step_axis_1 = float(grid[0, 0, 1, 1] - grid[0, 0, 0, 1])
+        torch.testing.assert_close(
+            torch.tensor(actual_step_axis_1),
+            torch.tensor(1.0 / 15),
+            rtol=1e-5,
+            atol=1e-6,
+        )
+
+    def test_l_cache_attribute_preserves_input(self):
+        emb_scalar = SIRENPositionalEmbeddingND(data_dim=3, embedding_dim=4, L_cache=10, omega_0=1.0)
+        emb_seq = SIRENPositionalEmbeddingND(data_dim=3, embedding_dim=4, L_cache=(8, 16, 32), omega_0=1.0)
+        assert emb_scalar.L_cache == 10
+        assert emb_seq.L_cache == (8, 16, 32)
+        assert emb_scalar.L_cache_per_axis == (10, 10, 10)
+        assert emb_seq.L_cache_per_axis == (8, 16, 32)
+
+
+# ---------------------------------------------------------------------------
+# SIRENKernelND — Wang init uses prod(L_per_axis)
+# ---------------------------------------------------------------------------
+
+
+class TestSIRENKernelAnisotropic:
+    def _build(self, L_cache):
+        torch.manual_seed(0)
+        return SIRENKernelND(
+            out_dim=4,
+            data_dim=3,
+            mlp_hidden_dim=8,
+            num_layers=2,
+            embedding_dim=8,
+            omega_0=10.0,
+            L_cache=L_cache,
+            use_bias=True,
+        )
+
+    def test_anisotropic_kernel_shape(self):
+        kern = self._build(L_cache=(8, 32, 64))
+        out, _ = kern(seq_lens=(8, 32, 64))
+        assert out.shape == (1, 15, 63, 127, 4)
+
+    def test_wang_init_uses_product_of_per_axis(self):
+        # Manually compare out_linear weight std before/after Wang scaling.
+        # The pre-Wang std equals the SIREN-init std for a (mlp_hidden_dim x out_dim) layer.
+        # We verify that the *ratio* between two configs equals the expected sqrt(prod ratio).
+        torch.manual_seed(0)
+        kern_iso = SIRENKernelND(
+            out_dim=4,
+            data_dim=3,
+            mlp_hidden_dim=8,
+            num_layers=2,
+            embedding_dim=8,
+            omega_0=10.0,
+            L_cache=(16, 16, 16),
+            use_bias=True,
+        )
+        torch.manual_seed(0)
+        kern_aniso = SIRENKernelND(
+            out_dim=4,
+            data_dim=3,
+            mlp_hidden_dim=8,
+            num_layers=2,
+            embedding_dim=8,
+            omega_0=10.0,
+            L_cache=(8, 16, 32),
+            use_bias=True,
+        )
+        # Same RNG ⇒ pre-Wang weights are identical; post-Wang they differ by
+        # sqrt(prod_aniso / prod_iso).  Hence the ratio of L2-norms equals
+        # sqrt(prod_aniso / prod_iso).
+        prod_iso = 16 * 16 * 16
+        prod_aniso = 8 * 16 * 32
+        ratio_expected = math.sqrt(prod_iso / prod_aniso)
+        ratio_actual = (kern_aniso.out_linear.weight.norm() / kern_iso.out_linear.weight.norm()).item()
+        assert math.isclose(ratio_actual, ratio_expected, rel_tol=1e-5), (
+            f"Wang scaling mismatch: actual ratio={ratio_actual:.6f}, expected={ratio_expected:.6f}"
+        )
+
+    def test_uniform_sequence_matches_scalar(self):
+        # L_cache=10 vs (10, 10, 10) → same kernel weights (same RNG).
+        torch.manual_seed(7)
+        kern_scalar = SIRENKernelND(
+            out_dim=4,
+            data_dim=3,
+            mlp_hidden_dim=8,
+            num_layers=2,
+            embedding_dim=8,
+            omega_0=5.0,
+            L_cache=10,
+            use_bias=True,
+        )
+        torch.manual_seed(7)
+        kern_seq = SIRENKernelND(
+            out_dim=4,
+            data_dim=3,
+            mlp_hidden_dim=8,
+            num_layers=2,
+            embedding_dim=8,
+            omega_0=5.0,
+            L_cache=(10, 10, 10),
+            use_bias=True,
+        )
+        torch.testing.assert_close(kern_scalar.out_linear.weight, kern_seq.out_linear.weight)
+        torch.testing.assert_close(
+            kern_scalar.positional_embedding.linear.weight,
+            kern_seq.positional_embedding.linear.weight,
+        )
+
+    def test_gradients_flow(self):
+        kern = self._build(L_cache=(8, 16, 16))
+        out, _ = kern(seq_lens=(8, 16, 16))
+        out.sum().backward()
+        assert all(p.grad is not None for p in kern.parameters() if p.requires_grad), (
+            "every kernel parameter should receive a gradient"
+        )
+
+
+# ---------------------------------------------------------------------------
+# RandomFourierPositionalEmbeddingND / RandomFourierKernelND
+# ---------------------------------------------------------------------------
+
+
+class TestRandomFourierAnisotropic:
+    def test_pos_emb_shape(self):
+        emb = RandomFourierPositionalEmbeddingND(data_dim=3, embedding_dim=4, L_cache=(4, 8, 16), omega_0=1.0)
+        assert emb.grid_cache.shape == (1, 7, 15, 31, 3)
+        out, grid = emb(seq_lens=(4, 8, 16))
+        assert out.shape == (1, 7, 15, 31, 4)
+        assert grid.shape == (1, 7, 15, 31, 3)
+
+    def test_kernel_shape_and_wang(self):
+        kern = RandomFourierKernelND(
+            out_dim=4,
+            data_dim=2,
+            mlp_hidden_dim=4,
+            num_layers=2,
+            embedding_dim=4,
+            omega_0=1.0,
+            L_cache=(8, 16),
+            use_bias=True,
+            nonlinear_cfg=LazyConfig(torch.nn.GELU)(),
+        )
+        out, _ = kern(seq_lens=(8, 16))
+        assert out.shape == (1, 15, 31, 4)
+        # Wang scaling uses prod(L_cache_per_axis)=128, matching ``isotropic`` 8x16.
+        assert kern.L_cache_per_axis == (8, 16)
+
+
+# ---------------------------------------------------------------------------
+# Subclass pass-through: MultiOmega / Learnable-ω₀ variants
+# ---------------------------------------------------------------------------
+
+
+class TestSubclassPassThrough:
+    def test_multi_omega_sequence_l_cache(self):
+        kern = MultiOmegaSIRENKernelND(
+            out_dim=4,
+            data_dim=3,
+            mlp_hidden_dim=8,
+            num_layers=2,
+            embedding_dim=8,
+            omega_0_per_row=[1.0] * 8,
+            L_cache=(8, 16, 32),
+            use_bias=True,
+        )
+        out, _ = kern(seq_lens=(8, 16, 32))
+        assert out.shape == (1, 15, 31, 63, 4)
+        assert kern.positional_embedding.L_cache_per_axis == (8, 16, 32)
+
+    def test_block_diagonal_multi_omega_sequence_l_cache(self):
+        kern = BlockDiagonalMultiOmegaSIRENKernelND(
+            out_dim=8,
+            data_dim=3,
+            mlp_hidden_dim=8,
+            num_layers=2,
+            embedding_dim=8,
+            L_cache=(8, 16, 32),
+            use_bias=True,
+            num_blocks=2,
+            omega_0_min=1.0,
+            omega_0_max=4.0,
+        )
+        out, _ = kern(seq_lens=(8, 16, 32))
+        assert out.shape == (1, 15, 31, 63, 8)
+
+    def test_learnable_omega_sequence_l_cache(self):
+        kern = LearnableOmegaSIRENKernelND(
+            out_dim=4,
+            data_dim=3,
+            mlp_hidden_dim=8,
+            num_layers=2,
+            embedding_dim=8,
+            omega_0=10.0,
+            L_cache=(8, 16, 32),
+            use_bias=True,
+        )
+        out, _ = kern(seq_lens=(8, 16, 32))
+        assert out.shape == (1, 15, 31, 63, 4)
+        assert kern.positional_embedding.L_cache_per_axis == (8, 16, 32)
+
+    def test_block_diagonal_learnable_omega_sequence_l_cache(self):
+        kern = BlockDiagonalLearnableOmegaSIRENKernelND(
+            out_dim=8,
+            data_dim=3,
+            mlp_hidden_dim=8,
+            num_layers=2,
+            embedding_dim=8,
+            L_cache=(8, 16, 32),
+            use_bias=True,
+            num_blocks=2,
+        )
+        out, _ = kern(seq_lens=(8, 16, 32))
+        assert out.shape == (1, 15, 31, 63, 8)
+
+
+# ---------------------------------------------------------------------------
+# CKConvND plumbing: L_cache + grid_size injection on anisotropic configs
+# ---------------------------------------------------------------------------
+
+
+class TestCKConvAnisotropic:
+    @staticmethod
+    def _kernel_cfg(L_cache):
+        return LazyConfig(SIRENKernelND)(
+            out_dim=4,
+            data_dim=3,
+            mlp_hidden_dim=4,
+            num_layers=2,
+            embedding_dim=4,
+            omega_0=10.0,
+            L_cache=L_cache,
+            use_bias=True,
+        )
+
+    @staticmethod
+    def _mask_cfg():
+        return LazyConfig(GaussianModulationND)(
+            data_dim=3,
+            num_channels=4,
+            grid_size=1,  # placeholder; CKConv will overwrite based on L_cache
+        )
+
+    def test_double_grid_passes_l_cache_through(self):
+        kern_cfg = self._kernel_cfg((8, 16, 32))
+        mask_cfg = self._mask_cfg()
+        ck = CKConvND(
+            data_dim=3,
+            hidden_dim=4,
+            kernel_cfg=kern_cfg,
+            mask_cfg=mask_cfg,
+            grid_type="double",
+            fft_padding="zero",
+        )
+        # double-grid does not shrink L_cache; the kernel sees the original sequence.
+        assert ck.kernel.L_cache_per_axis == (8, 16, 32)
+        # mask grid_size is set to the *largest* per-axis cache → 2*32 - 1.
+        assert ck.mask.std_param.shape[0] == 3  # data_dim
+        # Reverse-engineer ``grid_size`` from the stored ``_min_step``:
+        # ``_min_step = 2 / (grid_size - 1)`` ⇒ grid_size = 2/_min_step + 1.
+        gs = round(2.0 / ck.mask._min_step + 1)
+        assert gs == 2 * 32 - 1
+
+    def test_single_grid_halves_l_cache_per_axis(self):
+        kern_cfg = self._kernel_cfg((8, 16, 32))
+        mask_cfg = self._mask_cfg()
+        ck = CKConvND(
+            data_dim=3,
+            hidden_dim=4,
+            kernel_cfg=kern_cfg,
+            mask_cfg=mask_cfg,
+            grid_type="single",
+            fft_padding="zero",
+        )
+        # single-grid halves each axis: (L+1)//2 → (4, 8, 16).
+        assert ck.kernel.L_cache_per_axis == (4, 8, 16)
+        # mask grid_size uses 2 * max(per_axis) - 1 = 2*16 - 1 = 31.
+        gs = round(2.0 / ck.mask._min_step + 1)
+        assert gs == 2 * 16 - 1
+
+    def test_scalar_l_cache_unchanged_behaviour(self):
+        # Backward compat: a scalar L_cache still goes through CKConv unchanged.
+        kern_cfg = self._kernel_cfg(16)
+        mask_cfg = self._mask_cfg()
+        ck = CKConvND(
+            data_dim=3,
+            hidden_dim=4,
+            kernel_cfg=kern_cfg,
+            mask_cfg=mask_cfg,
+            grid_type="single",
+            fft_padding="zero",
+        )
+        # single-grid halves: (16+1)//2 = 8.  Scalar in → scalar out.
+        assert ck.kernel.L_cache == 8
+        assert ck.kernel.L_cache_per_axis == (8, 8, 8)
+        gs = round(2.0 / ck.mask._min_step + 1)
+        assert gs == 2 * 8 - 1
+
+    def test_forward_runs_on_anisotropic_grid(self):
+        kern_cfg = self._kernel_cfg((4, 8, 16))
+        mask_cfg = self._mask_cfg()
+        ck = CKConvND(
+            data_dim=3,
+            hidden_dim=4,
+            kernel_cfg=kern_cfg,
+            mask_cfg=mask_cfg,
+            grid_type="double",
+            fft_padding="zero",
+        )
+        # Input shape (B=1, C=4, D=4, H=8, W=16) — match L_cache exactly.
+        x = torch.randn(1, 4, 4, 8, 16)
+        out = ck(x, is_bhl_input=True)
+        assert out.shape == x.shape

--- a/tests/modules/test_masks_nd.py
+++ b/tests/modules/test_masks_nd.py
@@ -162,24 +162,43 @@ class TestGaussianModulationND:
 
     # -- init_extent and the hardcoded 0.1 attenuation -----------------
 
-    def test_init_extent_attenuation_is_01(self):
-        """Widest initial channel has 0.1 (1D) mask value at init_extent position.
+    def test_init_extent_attenuation_is_01_when_unclamped(self):
+        """When the (extent · 0.4724) high end fits inside [min_std, max_std],
+        the widest initial channel has the expected 1D mask value of 0.1 at
+        position ``extent``.
 
-        This is the core property: init_std_high is computed from a hardcoded
-        attenuation of 0.1 at the init_extent position along a single axis.
-        Note: clamping to max_std only happens during forward (via hook), so
-        the raw parameter value equals _std_from_attenuation(0.1, extent, 1).
+        ``init_extent`` multiplicatively scales both ends of the per-axis
+        logspace ramp.  As long as the high end isn't clipped by the
+        ``max_std`` clamp, the relationship
+        ``init_std_high = _std_from_attenuation(0.1, extent, 1)`` holds.
         """
-        for extent in [0.25, 0.5, 0.75, 1.0]:
+        # _make_mask uses min_attn=0.1, max_attn=0.05, grid_size=31 →
+        # max_std ≈ 0.4087, init_std_high_unit ≈ 0.4724.  Pick extents
+        # small enough that ``extent · 0.4724 < max_std``.
+        max_std = _std_from_attenuation(0.05, 1.0, 1)
+        init_std_high_unit = _std_from_attenuation(0.1, 1.0, 1)
+        for extent in [0.25, 0.5, 0.75]:
+            assert extent * init_std_high_unit < max_std, "test setup: extent must keep high end unclamped"
             mask = self._make_mask(init_extent=extent, num_ch=256)
             init_std_high = mask.std_param.data.max().item()
             expected_std = _std_from_attenuation(0.1, extent, 1)
             assert init_std_high == pytest.approx(expected_std, rel=1e-3)
 
+    def test_init_extent_high_end_is_clamped_to_max_std(self):
+        """When ``extent · init_std_high_unit`` exceeds ``max_std``, the high
+        end of the ramp is clamped at ``max_std``."""
+        mask = self._make_mask(init_extent=1.0, num_ch=256)
+        # extent=1.0 with the test config has init_std_high_unit > max_std,
+        # so the high end must clip exactly at max_std.
+        init_std_high_unit = _std_from_attenuation(0.1, 1.0, 1)
+        assert init_std_high_unit > mask.max_std
+        init_std_high = mask.std_param.data.max().item()
+        assert init_std_high == pytest.approx(mask.max_std, rel=1e-6)
+
     def test_init_extent_mask_value_matches_1d(self):
-        """Evaluate the mask at (init_extent, 0) — the single-axis value should
-        be close to 0.1 (or smaller if clamped to max_std)."""
-        extent = 0.5
+        """Evaluate the mask at (init_extent, 0) — for an unclamped ``extent``
+        the single-axis value should be close to 0.1."""
+        extent = 0.5  # unclamped at default test config
         mask = self._make_mask(init_extent=extent, num_ch=64)
         grid = self._make_grid()
         x = torch.ones(1, GRID_SIZE_31, GRID_SIZE_31, 64)
@@ -191,16 +210,40 @@ class TestGaussianModulationND:
         widest_ch = 63  # last channel = widest
 
         mask_val = out[0, idx, center, widest_ch].item()
-        # The grid may not hit exactly `extent`, so we check within tolerance
-        # of the discretization error plus the 0.1 target.
         assert mask_val < 0.15, f"Expected near 0.1 at extent={extent}, got {mask_val}"
         assert mask_val > 0.01, f"Unexpectedly low: {mask_val}"
 
     def test_smaller_extent_gives_smaller_init_std_high(self):
-        """More local init_extent should give a smaller init_std_high."""
+        """More local init_extent should give a smaller init_std_high (low end too)."""
         mask_global = self._make_mask(init_extent=1.0)
         mask_local = self._make_mask(init_extent=0.25)
         assert mask_local.std_param.data.max().item() < mask_global.std_param.data.max().item()
+        # And the low end also moves: with multiplicative scaling, a smaller
+        # extent pushes the bottom of the ramp below the reference min_std.
+        assert mask_local.std_param.data.min().item() < mask_global.std_param.data.min().item() + 1e-12
+
+    def test_extent_above_one_lifts_low_end_of_ramp(self):
+        """``init_extent > 1`` must lift the **bottom** of the ramp above the
+        reference ``min_std`` — otherwise short anisotropic axes would still
+        have unusably-narrow channels at init.  This is the regression test
+        for the multiplicative semantic."""
+        mask_ref = self._make_mask(init_extent=1.0, num_ch=256)
+        mask_wide = self._make_mask(init_extent=4.0, num_ch=256)
+        ref_low = mask_ref.std_param.data.min().item()
+        wide_low = mask_wide.std_param.data.min().item()
+        # extent=4 should push the low end up by ~4x (modulo clamping).
+        # At default test config min_std ≈ 0.0314, max_std ≈ 0.4087, so
+        # 4*min_std ≈ 0.126 fits comfortably inside the band.
+        assert wide_low > ref_low * 3.5
+        assert wide_low <= mask_wide.max_std + 1e-6
+
+    def test_extent_saturates_entire_ramp_at_max_std(self):
+        """Sufficiently-large ``init_extent`` collapses the per-axis ramp to a
+        constant ``max_std`` (axis effectively unmasked at init)."""
+        mask = self._make_mask(init_extent=1e6, num_ch=64)
+        # Both ends saturate at max_std.
+        assert mask.std_param.data.min().item() == pytest.approx(mask.max_std, rel=1e-6)
+        assert mask.std_param.data.max().item() == pytest.approx(mask.max_std, rel=1e-6)
 
     # -- clamping -------------------------------------------------------
 
@@ -280,10 +323,17 @@ class TestGaussianModulationND:
             GaussianModulationND(data_dim=2, num_channels=4)
 
     def test_invalid_init_extent_raises(self):
+        # Must be strictly > 0 and finite. Values > 1 are now allowed
+        # (they multiplicatively scale the ramp — see the multiplicative
+        # semantic introduced for anisotropic kernel grids).
         with pytest.raises(ValueError, match="init_extent"):
             self._make_mask(init_extent=0.0)
         with pytest.raises(ValueError, match="init_extent"):
-            self._make_mask(init_extent=1.5)
+            self._make_mask(init_extent=-0.5)
+        with pytest.raises(ValueError, match="init_extent"):
+            self._make_mask(init_extent=float("inf"))
+        with pytest.raises(ValueError, match="init_extent"):
+            self._make_mask(init_extent=float("nan"))
 
     # -- per-axis init_extent -------------------------------------------
 
@@ -299,7 +349,13 @@ class TestGaussianModulationND:
         assert mask.std_param.shape == (3, 8)
 
     def test_per_axis_init_extent_sets_per_axis_init_std_high(self):
-        """Each axis ramps to its own init_std_high determined by its init_extent."""
+        """Each axis ramps to its own init_std_high determined by its init_extent.
+
+        Default ``GaussianModulationND`` uses ``max_attenuation_at_limit=0.95``
+        which gives ``max_std ≈ 3.121`` — much larger than
+        ``init_std_high_unit ≈ 0.4724`` — so the high ends here are NOT
+        clamped and equal ``_std_from_attenuation(0.1, extent, 1)`` exactly.
+        """
         extents = (1.0, 0.5, 0.25)
         mask = GaussianModulationND(
             data_dim=3,
@@ -309,8 +365,26 @@ class TestGaussianModulationND:
         )
         for axis, extent in enumerate(extents):
             expected_high = _std_from_attenuation(0.1, extent, 1)
+            assert expected_high < mask.max_std, "test setup: high end must fit inside the clamp band"
             actual_high = mask.std_param.data[axis].max().item()
             assert actual_high == pytest.approx(expected_high, rel=1e-3)
+
+    def test_per_axis_init_extent_above_one_lifts_per_axis_low(self):
+        """``init_extent[d] > 1`` lifts the *bottom* of axis-d's ramp above
+        ``min_std`` (multiplicative-semantic regression)."""
+        # Use the default mask config (min_attn=0.1, max_attn=0.95) so the
+        # clamp band is wide enough that 4× scaling fits comfortably.
+        mask = GaussianModulationND(
+            data_dim=3,
+            num_channels=64,
+            grid_size=127,  # matches an 8x64x64 anisotropic-grid config
+            init_extent=(4.0, 1.0, 1.0),
+        )
+        depth_low = mask.std_param.data[0].min().item()
+        hw_low = mask.std_param.data[1].min().item()
+        # H/W keep the reference low; depth is lifted by ~4x.
+        assert hw_low == pytest.approx(mask.min_std, rel=1e-3)
+        assert depth_low > 3.5 * mask.min_std
 
     def test_per_axis_init_extent_narrower_axis_narrower_widest_channel(self):
         """A smaller init_extent on one axis yields a narrower widest-channel
@@ -337,10 +411,14 @@ class TestGaussianModulationND:
             GaussianModulationND(data_dim=3, num_channels=8, grid_size=31, init_extent=(1.0, 0.5))
 
     def test_per_axis_init_extent_out_of_range_raises(self):
-        with pytest.raises(ValueError, match="init_extent"):
-            GaussianModulationND(data_dim=2, num_channels=8, grid_size=31, init_extent=(1.0, 1.5))
+        # Sequence values must each be strictly > 0 and finite. Values > 1
+        # are explicitly allowed (multiplicative semantic) and tested above.
         with pytest.raises(ValueError, match="init_extent"):
             GaussianModulationND(data_dim=2, num_channels=8, grid_size=31, init_extent=(0.5, 0.0))
+        with pytest.raises(ValueError, match="init_extent"):
+            GaussianModulationND(data_dim=2, num_channels=8, grid_size=31, init_extent=(1.0, -2.0))
+        with pytest.raises(ValueError, match="init_extent"):
+            GaussianModulationND(data_dim=2, num_channels=8, grid_size=31, init_extent=(1.0, float("inf")))
 
     def test_per_axis_init_extent_wrong_type_raises(self):
         with pytest.raises(TypeError, match="init_extent"):


### PR DESCRIPTION
## Summary

- **Anisotropic `L_cache`**: `L_cache` can now be a per-axis sequence (e.g. `(8, 64, 64)`) instead of a single int, giving each spatial axis its own kernel grid resolution. This avoids wasting grid points on short axes in anisotropic volumes (e.g. depth-height-width cubes where depth << height/width).
- **Mask `init_extent > 1`**: `GaussianModulationND` now accepts `init_extent > 1` so short axes can saturate the std ramp at `max_std` (i.e. "unmasked at init"), which is necessary when the mask's `min_std` is driven by the densest axis but a short axis cannot use narrow bandwidths.
- **3D spatial_recall_v2 configs**: New `color_conditioning_3d/` configs including a `hyena_gaussian_mask_aniso_grid.py` that combines the anisotropic grid with depth-axis mask saturation for the 8×64×64 volume.
- **ω₀ dimensional scaling report**: Derives and numerically verifies the √d rule for SIREN `omega_0` scaling across input dimensions, with full per-channel distribution analysis.
- **Misc**: RoPE removal from Hyena, `.gitignore` for `_tmp/`, wandb ablation helper.

### Commits

| Commit | Description |
|--------|-------------|
| `23709be` | Anisotropic per-axis `L_cache` for SIREN/RFF grids and masks |
| `53e9bb8` | gitignore `_tmp/` scratch directory |
| `309c7fa` | wandb ablation helper and WELL-dataset SLURM download script |
| `f6c9b6b` | SIREN ω₀ dimensional scaling report |
| `9600483` | 3D color_cond Hyena Gaussian mask + 2×2 ablation configs |
| `3c1d17c` | Per-axis `init_extent` for `GaussianModulationND` |
| `b0b18dd` | Remove RoPE from Hyena module and configs |

## Test plan

- [x] `tests/modules/test_kernels_nd.py` — covers `_normalize_l_cache`, anisotropic grid shapes, per-axis cache extension, CKConvND integration for both `grid_type='single'` and `'double'`
- [x] `tests/modules/test_masks_nd.py` — updated for `init_extent > 1`, high-end clamping, per-axis ramp scaling
- [ ] Run spatial_recall_v2 3D ablation on cluster to verify training convergence


Made with [Cursor](https://cursor.com)