### PR TITLE
Benchmarks: ImageNet throughput + 2D mixer patch-size sweep

### DIFF
--- a/scripts/benchmark_imagenet_throughput.py
+++ b/scripts/benchmark_imagenet_throughput.py
@@ -1,0 +1,605 @@
+"""Inference throughput benchmark for ImageNet-1k ViT-5 configs.
+
+Reports images/sec on a single GPU, comparable to the throughput numbers in
+VMamba Table 1 (https://arxiv.org/pdf/2401.10166).
+
+This script builds the *network* directly from ``nvsubquadratic`` modules — it
+does **not** load the full training-side config (which pulls in apex, DALI,
+lightning, etc.).  The four architectures benchmarked match the runs from
+``dwromero/blockdiag-kernel`` reported in the paper:
+
+    * full_hyena_learnable_omega_blockdiag (12H, learnable-ω₀ + block-diag)
+    * hhha_blockdiag                       (3:1 H:A)
+    * attention_pretrain                   (pure attn baseline)
+    * ha_blockdiag                         (1:1 H:A)
+
+Constants (HIDDEN_DIM=384, NUM_BLOCKS=12, image_size=224, patch_size=16,
+kernel hyperparameters, block-diag schedule, learnable-ω₀ clamp) are mirrored
+from:
+
+    examples/vit5_imagenet/v5/_base.py
+    examples/vit5_imagenet/vit5_hybrid/_base_config.py
+    examples/vit5_imagenet/vit5_hybrid/_blockdiag.py
+    examples/vit5_imagenet/vit5_hybrid/_learnable_omega.py
+    examples/vit5_imagenet/v5/attention_pretrain.py
+
+Protocol (matches Swin / VMamba): 224x224 mock inputs, BF16 autocast,
+``torch.no_grad`` + ``eval()``, optional ``torch.compile``, N warmup +
+M timed iterations using cuda events.
+
+Usage::
+
+    python scripts/benchmark_imagenet_throughput.py
+    python scripts/benchmark_imagenet_throughput.py --batch-size 4 --no-compile  # smoketest
+    python scripts/benchmark_imagenet_throughput.py --batch-size 256 --dtype fp16
+"""
+
+from __future__ import annotations
+
+import argparse
+import gc
+import sys
+import time
+from pathlib import Path
+from typing import Callable
+
+import torch
+
+# Ensure project root is on sys.path so nvsubquadratic.* is importable.
+_PROJECT_ROOT = Path(__file__).resolve().parent.parent
+if str(_PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(_PROJECT_ROOT))
+
+from nvsubquadratic.lazy_config import LazyConfig, instantiate  # noqa: E402
+from nvsubquadratic.modules.ckconv_nd import CKConvND  # noqa: E402
+from nvsubquadratic.modules.grn import GlobalResponseNorm  # noqa: E402
+from nvsubquadratic.modules.hyena_nd import Hyena  # noqa: E402
+from nvsubquadratic.modules.kernels_nd import (  # noqa: E402
+    BlockDiagonalLearnableOmegaSIRENKernelND,
+    BlockDiagonalMultiOmegaSIRENKernelND,
+    SIRENKernelND,
+)
+from nvsubquadratic.modules.masks_nd import (  # noqa: E402
+    BlockAlignedGaussianModulationND,
+    GaussianModulationND,
+)
+from nvsubquadratic.modules.mlp import MLP  # noqa: E402
+from nvsubquadratic.modules.rms_norm import RMSNorm  # noqa: E402
+from nvsubquadratic.modules.sequence_mixer import QKVSequenceMixer  # noqa: E402
+from nvsubquadratic.modules.vit5_attention import ViT5Attention  # noqa: E402
+from nvsubquadratic.modules.vit5_hyena_adapter import ViT5HyenaAdapter  # noqa: E402
+from nvsubquadratic.modules.vit5_residual_block import ViT5ResidualBlock  # noqa: E402
+from nvsubquadratic.networks.vit5_classification import ViT5ClassificationNet  # noqa: E402
+from nvsubquadratic.utils.init import (  # noqa: E402
+    trunc_normal_init,
+    trunc_normal_init_factory,
+)
+from nvsubquadratic.utils.qk_norm import L2Norm  # noqa: E402
+
+
+# ─── Mirrored constants ───────────────────────────────────────────────────────
+INPUT_CHANNELS = 3
+NUM_CLASSES = 1000
+IMAGE_SIZE = 224
+HIDDEN_DIM = 384
+NUM_BLOCKS = 12
+PATCH_SIZE = 16
+LAYER_SCALE_INIT = 1e-4
+MLP_RATIO = 4
+NUM_HEADS = 6
+NUM_REGISTERS = 4
+DROP_PATH_RATE = 0.05  # ignored at inference (we eval()), kept for parity
+
+# SIREN kernel hyperparameters
+KERNEL_MLP_HIDDEN_DIM = 32
+KERNEL_NUM_LAYERS = 3
+KERNEL_EMBEDDING_DIM = 32
+KERNEL_OMEGA_0 = 10.0
+KERNEL_HIDDEN_OMEGA_0 = 1.0
+
+# Block-diagonal schedule defaults (from _blockdiag.py)
+BD_NUM_BLOCKS = 8
+BD_OMEGA_0_MIN = 1.0
+BD_OMEGA_0_MAX = 12.0
+BD_SCHEDULE = "linear"
+BD_OFF_BLOCK_SCALE = 0.1
+
+# Learnable-ω₀ clamp + LR-scale (from _learnable_omega.py)
+LO_SCALE_MIN = 1e-2
+LO_SCALE_MAX = 2.0
+LO_APPLY_LR_SCALE = True
+
+INIT_FN = trunc_normal_init(std=0.02)
+INIT_FN_FACTORY = trunc_normal_init_factory(std=0.02)
+
+
+def _grid_h(num_patches_w: int, num_registers: int) -> int:
+    """Replicates the _GRID_H interpolation expression for L_cache.
+
+    Mirrors:
+        ((W**2 + 1 + R + (-(W**2 + 1 + R) % W)) // W)
+    where ``W = image_size // patch_size``.
+    """
+    W = num_patches_w
+    R = num_registers
+    pad = (-(W**2) - 1 - R) % W
+    return (W**2 + 1 + R + pad) // W
+
+
+# ─── Block builders ───────────────────────────────────────────────────────────
+
+
+def _attention_block(num_patches_w: int, num_registers: int) -> LazyConfig:
+    return LazyConfig(ViT5ResidualBlock)(
+        sequence_mixer_cfg=LazyConfig(ViT5Attention)(
+            hidden_dim=HIDDEN_DIM,
+            num_heads=NUM_HEADS,
+            num_patches_h=num_patches_w,
+            num_patches_w=num_patches_w,
+            num_registers=num_registers,
+            qk_norm=LazyConfig(RMSNorm)(dim=HIDDEN_DIM // NUM_HEADS, eps=1e-6),
+            rope_base=10000.0,
+            reg_rope_base=100.0,
+            attn_dropout=0.0,
+            proj_dropout=0.0,
+            qkv_bias=False,
+            out_proj_bias=False,
+            init_fn_qkv_proj=INIT_FN,
+            init_fn_out_proj=INIT_FN,
+        ),
+        sequence_mixer_norm_cfg=LazyConfig(RMSNorm)(dim=HIDDEN_DIM, eps=1e-6),
+        mlp_cfg=LazyConfig(MLP)(
+            dim=HIDDEN_DIM,
+            activation="gelu",
+            expansion_factor=float(MLP_RATIO),
+            bias=False,
+            dropout_cfg=LazyConfig(torch.nn.Dropout)(p=0.0),
+            init_method_in=INIT_FN_FACTORY,
+            init_method_out=INIT_FN_FACTORY,
+        ),
+        mlp_norm_cfg=LazyConfig(RMSNorm)(dim=HIDDEN_DIM, eps=1e-6),
+        hidden_dim=HIDDEN_DIM,
+        layer_scale_init=LAYER_SCALE_INIT,
+    )
+
+
+def _hyena_block(
+    num_patches_w: int,
+    num_registers: int,
+    *,
+    kernel_variant: str,  # "siren" | "blockdiag" | "blockdiag_learnable"
+    fft_backend: str = "subq_ops",
+) -> LazyConfig:
+    L_cache = _grid_h(num_patches_w, num_registers)
+
+    if kernel_variant == "siren":
+        kernel_cfg = LazyConfig(SIRENKernelND)(
+            data_dim=2,
+            out_dim=HIDDEN_DIM,
+            mlp_hidden_dim=KERNEL_MLP_HIDDEN_DIM,
+            num_layers=KERNEL_NUM_LAYERS,
+            embedding_dim=KERNEL_EMBEDDING_DIM,
+            omega_0=KERNEL_OMEGA_0,
+            L_cache=L_cache,
+            use_bias=True,
+            hidden_omega_0=KERNEL_HIDDEN_OMEGA_0,
+        )
+        mask_cfg = LazyConfig(GaussianModulationND)(
+            data_dim=2,
+            num_channels=HIDDEN_DIM,
+            min_attenuation_at_step=0.1,
+            max_attenuation_at_limit=0.95,
+            init_extent=1.0,
+            parametrization="direct",
+        )
+    elif kernel_variant == "blockdiag":
+        kernel_cfg = LazyConfig(BlockDiagonalMultiOmegaSIRENKernelND)(
+            data_dim=2,
+            out_dim=HIDDEN_DIM,
+            mlp_hidden_dim=KERNEL_MLP_HIDDEN_DIM,
+            num_layers=KERNEL_NUM_LAYERS,
+            embedding_dim=KERNEL_EMBEDDING_DIM,
+            L_cache=L_cache,
+            use_bias=True,
+            hidden_omega_0=KERNEL_HIDDEN_OMEGA_0,
+            num_blocks=BD_NUM_BLOCKS,
+            omega_0_min=BD_OMEGA_0_MIN,
+            omega_0_max=BD_OMEGA_0_MAX,
+            schedule=BD_SCHEDULE,
+            off_block_scale=BD_OFF_BLOCK_SCALE,
+        )
+        mask_cfg = LazyConfig(BlockAlignedGaussianModulationND)(
+            data_dim=2,
+            num_channels=HIDDEN_DIM,
+            min_attenuation_at_step=0.1,
+            max_attenuation_at_limit=0.95,
+            init_extent=1.0,
+            parametrization="direct",
+        )
+    elif kernel_variant == "blockdiag_learnable":
+        kernel_cfg = LazyConfig(BlockDiagonalLearnableOmegaSIRENKernelND)(
+            data_dim=2,
+            out_dim=HIDDEN_DIM,
+            mlp_hidden_dim=KERNEL_MLP_HIDDEN_DIM,
+            num_layers=KERNEL_NUM_LAYERS,
+            embedding_dim=KERNEL_EMBEDDING_DIM,
+            L_cache=L_cache,
+            use_bias=True,
+            hidden_omega_0=KERNEL_HIDDEN_OMEGA_0,
+            num_blocks=BD_NUM_BLOCKS,
+            omega_0_min=BD_OMEGA_0_MIN,
+            omega_0_max=BD_OMEGA_0_MAX,
+            schedule=BD_SCHEDULE,
+            off_block_scale=BD_OFF_BLOCK_SCALE,
+            omega_0_scale_min=LO_SCALE_MIN,
+            omega_0_scale_max=LO_SCALE_MAX,
+            apply_lr_scale=LO_APPLY_LR_SCALE,
+        )
+        mask_cfg = LazyConfig(BlockAlignedGaussianModulationND)(
+            data_dim=2,
+            num_channels=HIDDEN_DIM,
+            min_attenuation_at_step=0.1,
+            max_attenuation_at_limit=0.95,
+            init_extent=1.0,
+            parametrization="direct",
+        )
+    else:
+        raise ValueError(f"unknown kernel_variant: {kernel_variant}")
+
+    mixer_cfg = LazyConfig(QKVSequenceMixer)(
+        hidden_dim=HIDDEN_DIM,
+        mixer_cfg=LazyConfig(Hyena)(
+            global_conv_cfg=LazyConfig(CKConvND)(
+                data_dim=2,
+                hidden_dim=HIDDEN_DIM,
+                kernel_cfg=kernel_cfg,
+                mask_cfg=mask_cfg,
+                grid_type="double",
+                fft_padding="zero",
+                fft_backend=fft_backend,
+            ),
+            short_conv_cfg=LazyConfig(torch.nn.Conv2d)(
+                in_channels=3 * HIDDEN_DIM,
+                out_channels=3 * HIDDEN_DIM,
+                kernel_size=3,
+                groups=3 * HIDDEN_DIM,
+                padding=1,
+                bias=False,
+            ),
+            gate_nonlinear_cfg=LazyConfig(torch.nn.SiLU)(),
+            pixelhyena_norm_cfg=LazyConfig(RMSNorm)(dim=HIDDEN_DIM, eps=1e-6),
+            qk_norm_cfg=LazyConfig(L2Norm)(),
+            use_rope=False,
+            output_norm_cfg=LazyConfig(RMSNorm)(dim=HIDDEN_DIM, eps=1e-6),
+            gate_nonlinear_2_cfg=LazyConfig(torch.nn.Sigmoid)(),
+        ),
+        qkv_bias=False,
+        out_proj_bias=False,
+        init_method_in=INIT_FN_FACTORY,
+        init_method_out=INIT_FN_FACTORY,
+    )
+
+    return LazyConfig(ViT5ResidualBlock)(
+        sequence_mixer_cfg=LazyConfig(ViT5HyenaAdapter)(
+            inner_mixer_cfg=mixer_cfg,
+            grid_w=num_patches_w,
+        ),
+        sequence_mixer_norm_cfg=LazyConfig(RMSNorm)(dim=HIDDEN_DIM, eps=1e-6),
+        mlp_cfg=LazyConfig(MLP)(
+            dim=HIDDEN_DIM,
+            activation="gelu",
+            expansion_factor=float(MLP_RATIO),
+            bias=False,
+            dropout_cfg=LazyConfig(torch.nn.Dropout)(p=0.0),
+            init_method_in=INIT_FN_FACTORY,
+            init_method_out=INIT_FN_FACTORY,
+        ),
+        mlp_norm_cfg=LazyConfig(RMSNorm)(dim=HIDDEN_DIM, eps=1e-6),
+        hidden_dim=HIDDEN_DIM,
+        layer_scale_init=LAYER_SCALE_INIT,
+        grn_cfg=LazyConfig(GlobalResponseNorm)(dim=HIDDEN_DIM),
+    )
+
+
+# ─── Network builders ─────────────────────────────────────────────────────────
+
+
+def build_hybrid(layer_pattern: str, kernel_variant: str, fft_backend: str = "subq_ops") -> LazyConfig:
+    num_patches_w = IMAGE_SIZE // PATCH_SIZE
+    layer_types: dict[str, LazyConfig] = {}
+    if "A" in layer_pattern:
+        layer_types["A"] = _attention_block(num_patches_w, NUM_REGISTERS)
+    if "H" in layer_pattern:
+        layer_types["H"] = _hyena_block(
+            num_patches_w, NUM_REGISTERS, kernel_variant=kernel_variant, fft_backend=fft_backend
+        )
+    return LazyConfig(ViT5ClassificationNet)(
+        in_channels=INPUT_CHANNELS,
+        num_classes=NUM_CLASSES,
+        hidden_dim=HIDDEN_DIM,
+        num_blocks=len(layer_pattern),
+        patch_size=PATCH_SIZE,
+        image_size=IMAGE_SIZE,
+        num_registers=NUM_REGISTERS,
+        dropout_rate=0.0,
+        readout="cls",
+        norm_cfg=LazyConfig(RMSNorm)(dim=HIDDEN_DIM, eps=1e-6),
+        layer_pattern=layer_pattern,
+        layer_types=layer_types,
+        max_drop_path_rate=DROP_PATH_RATE,
+        drop_path_schedule="constant",
+    )
+
+
+def build_attention_pretrain() -> LazyConfig:
+    """Replicates examples/vit5_imagenet/v5/attention_pretrain.py."""
+    num_patches_w = IMAGE_SIZE // PATCH_SIZE
+    return LazyConfig(ViT5ClassificationNet)(
+        in_channels=INPUT_CHANNELS,
+        num_classes=NUM_CLASSES,
+        hidden_dim=HIDDEN_DIM,
+        num_blocks=NUM_BLOCKS,
+        patch_size=PATCH_SIZE,
+        image_size=IMAGE_SIZE,
+        num_registers=NUM_REGISTERS,
+        dropout_rate=0.0,
+        readout="cls",
+        norm_cfg=LazyConfig(RMSNorm)(dim=HIDDEN_DIM, eps=1e-6),
+        block_cfg=LazyConfig(ViT5ResidualBlock)(
+            sequence_mixer_cfg=LazyConfig(ViT5Attention)(
+                hidden_dim=HIDDEN_DIM,
+                num_heads=NUM_HEADS,
+                num_patches_h=num_patches_w,
+                num_patches_w=num_patches_w,
+                num_registers=NUM_REGISTERS,
+                qk_norm=LazyConfig(RMSNorm)(dim=HIDDEN_DIM // NUM_HEADS, eps=1e-6),
+                rope_base=10000.0,
+                reg_rope_base=100.0,
+                attn_dropout=0.0,
+                proj_dropout=0.0,
+                qkv_bias=False,
+                out_proj_bias=False,
+                init_fn_qkv_proj=INIT_FN,
+                init_fn_out_proj=INIT_FN,
+            ),
+            sequence_mixer_norm_cfg=LazyConfig(RMSNorm)(dim=HIDDEN_DIM, eps=1e-6),
+            mlp_cfg=LazyConfig(MLP)(
+                dim=HIDDEN_DIM,
+                activation="gelu",
+                expansion_factor=float(MLP_RATIO),
+                bias=False,
+                dropout_cfg=LazyConfig(torch.nn.Dropout)(p=0.0),
+                init_method_in=INIT_FN_FACTORY,
+                init_method_out=INIT_FN_FACTORY,
+            ),
+            mlp_norm_cfg=LazyConfig(RMSNorm)(dim=HIDDEN_DIM, eps=1e-6),
+            hidden_dim=HIDDEN_DIM,
+            layer_scale_init=LAYER_SCALE_INIT,
+            drop_path_rate=DROP_PATH_RATE,
+        ),
+    )
+
+
+# Names + builders + whether the model uses FFT conv (Hyena).
+# Builders take a single ``fft_backend`` arg so the CLI can pick between the
+# native ``torch_fft`` path (works anywhere) and the optimized ``subq_ops``
+# CUDA kernels (production).
+MODELS: list[tuple[str, Callable[[str], LazyConfig], bool]] = [
+    (
+        "full_hyena_learnable_omega_blockdiag",
+        lambda fft: build_hybrid("H" * 12, "blockdiag_learnable", fft_backend=fft),
+        True,
+    ),
+    (
+        "hhha_blockdiag (3H:1A)",
+        lambda fft: build_hybrid("HHHA" * 3, "blockdiag", fft_backend=fft),
+        True,
+    ),
+    (
+        "attention_pretrain (pure attn)",
+        lambda fft: build_attention_pretrain(),
+        False,
+    ),
+    (
+        "ha_blockdiag (1H:1A)",
+        lambda fft: build_hybrid("HA" * 6, "blockdiag", fft_backend=fft),
+        True,
+    ),
+]
+
+
+def _make_inputs(batch_size: int, image_size: int, device: torch.device) -> dict[str, torch.Tensor]:
+    """ViT5ClassificationNet expects input as [B, H, W, C] channels-last."""
+    x = torch.randn(batch_size, image_size, image_size, 3, device=device, dtype=torch.float32)
+    c = torch.zeros(batch_size, image_size, image_size, 0, device=device, dtype=torch.float32)
+    return {"input": x, "condition": c}
+
+
+def benchmark(
+    name: str,
+    builder: Callable[[str], LazyConfig],
+    has_fft: bool,
+    *,
+    batch_size: int,
+    image_size: int,
+    dtype: torch.dtype,
+    num_warmup: int,
+    num_iters: int,
+    compile_mode: str | None,
+    device: torch.device,
+    fft_backend: str,
+) -> dict[str, float]:
+    print(f"\n{'=' * 72}")
+    print(f"[{name}]")
+    print(f"{'=' * 72}", flush=True)
+
+    if has_fft and compile_mode is not None:
+        # FFT conv needs the real-valued complex multiply path under torch.compile.
+        import nvsubquadratic.ops.fftconv as _fftconv
+
+        _fftconv.COMPILE_COMPATIBLE = True
+        print("[setup] FFT compile-compat enabled", flush=True)
+
+    network = instantiate(builder(fft_backend)).to(device).eval()
+    n_params = sum(p.numel() for p in network.parameters())
+    print(f"[setup] params: {n_params:,}", flush=True)
+
+    if compile_mode is not None:
+        print(f"[setup] torch.compile(mode={compile_mode!r}) ...", flush=True)
+        network = torch.compile(network, mode=compile_mode)
+
+    inputs = _make_inputs(batch_size, image_size, device)
+    torch.cuda.reset_peak_memory_stats(device)
+
+    print(f"[warmup] {num_warmup} iters ...", flush=True)
+    t_compile_start = time.perf_counter()
+    with torch.inference_mode(), torch.autocast("cuda", dtype=dtype):
+        for _ in range(num_warmup):
+            _ = network(inputs)
+    torch.cuda.synchronize(device)
+    compile_secs = time.perf_counter() - t_compile_start
+
+    print(f"[timed] {num_iters} iters ...", flush=True)
+    start = torch.cuda.Event(enable_timing=True)
+    end = torch.cuda.Event(enable_timing=True)
+    torch.cuda.synchronize(device)
+    start.record()
+    with torch.inference_mode(), torch.autocast("cuda", dtype=dtype):
+        for _ in range(num_iters):
+            _ = network(inputs)
+    end.record()
+    torch.cuda.synchronize(device)
+
+    elapsed_ms = start.elapsed_time(end)
+    elapsed_s = elapsed_ms / 1000.0
+    imgs_per_sec = (batch_size * num_iters) / elapsed_s
+    ms_per_batch = elapsed_ms / num_iters
+    peak_mem_gb = torch.cuda.max_memory_allocated(device) / (1024**3)
+
+    print(
+        f"[result] imgs/s = {imgs_per_sec:>9.1f}  |  "
+        f"{ms_per_batch:6.2f} ms/batch  |  "
+        f"peak mem = {peak_mem_gb:5.2f} GB  |  "
+        f"warmup+compile = {compile_secs:6.1f}s",
+        flush=True,
+    )
+
+    del network, inputs
+    gc.collect()
+    torch.cuda.empty_cache()
+    if hasattr(torch, "_dynamo"):
+        torch._dynamo.reset()
+
+    return {
+        "name": name,
+        "params": n_params,
+        "imgs_per_sec": imgs_per_sec,
+        "ms_per_batch": ms_per_batch,
+        "peak_mem_gb": peak_mem_gb,
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--batch-size", type=int, default=128, help="Inference batch size (VMamba uses 128).")
+    parser.add_argument("--image-size", type=int, default=IMAGE_SIZE, help="Input spatial resolution.")
+    parser.add_argument("--num-warmup", type=int, default=30, help="Warmup iterations (also covers compile).")
+    parser.add_argument("--num-iters", type=int, default=50, help="Timed iterations.")
+    parser.add_argument(
+        "--dtype",
+        choices=["bf16", "fp16", "fp32"],
+        default="bf16",
+        help="Autocast dtype (bf16 is the H100 default).",
+    )
+    parser.add_argument(
+        "--compile-mode",
+        type=str,
+        default="max-autotune-no-cudagraphs",
+        help="torch.compile mode (matches the training configs). Use --no-compile to disable.",
+    )
+    parser.add_argument("--no-compile", action="store_true", help="Disable torch.compile entirely.")
+    parser.add_argument(
+        "--fft-backend",
+        choices=["torch_fft", "subq_ops"],
+        default="subq_ops",
+        help="FFT conv backend for Hyena blocks. Use 'torch_fft' on hosts without the subq_ops CUDA kernels.",
+    )
+    parser.add_argument(
+        "--models",
+        nargs="+",
+        default=None,
+        help="Subset of model names to run (substring match). Default: all 4.",
+    )
+    args = parser.parse_args()
+
+    if not torch.cuda.is_available():
+        raise SystemExit("CUDA device required for throughput benchmark.")
+    device = torch.device("cuda")
+    torch.backends.cudnn.benchmark = True
+    torch.set_float32_matmul_precision("high")
+
+    dtype_map = {"bf16": torch.bfloat16, "fp16": torch.float16, "fp32": torch.float32}
+    dtype = dtype_map[args.dtype]
+    compile_mode = None if args.no_compile else args.compile_mode
+
+    selected = MODELS
+    if args.models:
+        selected = [m for m in MODELS if any(s in m[0] for s in args.models)]
+        if not selected:
+            raise SystemExit(f"No models match {args.models!r}")
+
+    print(f"Device: {torch.cuda.get_device_name(device)}")
+    print(
+        f"Settings: batch_size={args.batch_size} image_size={args.image_size} "
+        f"dtype={args.dtype} compile={compile_mode} fft_backend={args.fft_backend} "
+        f"warmup={args.num_warmup} timed={args.num_iters}"
+    )
+
+    results: list[dict[str, float]] = []
+    for name, builder, has_fft in selected:
+        try:
+            results.append(
+                benchmark(
+                    name,
+                    builder,
+                    has_fft,
+                    batch_size=args.batch_size,
+                    image_size=args.image_size,
+                    dtype=dtype,
+                    num_warmup=args.num_warmup,
+                    num_iters=args.num_iters,
+                    compile_mode=compile_mode,
+                    device=device,
+                    fft_backend=args.fft_backend,
+                )
+            )
+        except Exception as exc:  # noqa: BLE001
+            print(f"[error] {name} failed: {exc!r}", flush=True)
+            results.append(
+                {
+                    "name": name,
+                    "params": 0,
+                    "imgs_per_sec": float("nan"),
+                    "ms_per_batch": float("nan"),
+                    "peak_mem_gb": float("nan"),
+                }
+            )
+
+    print(f"\n{'=' * 72}")
+    print("Throughput summary  (higher imgs/s is better)")
+    print(f"{'=' * 72}")
+    print(f"{'Model':<40s} {'Params':>10s} {'imgs/s':>10s} {'ms/batch':>10s} {'GB':>6s}")
+    print("-" * 80)
+    for r in results:
+        params_m = r["params"] / 1e6 if r["params"] else float("nan")
+        print(
+            f"{r['name']:<40s} "
+            f"{params_m:>9.1f}M "
+            f"{r['imgs_per_sec']:>10.1f} "
+            f"{r['ms_per_batch']:>10.2f} "
+            f"{r['peak_mem_gb']:>6.2f}"
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/benchmark_imagenet_throughput.py
+++ b/scripts/benchmark_imagenet_throughput.py
@@ -45,36 +45,37 @@ from typing import Callable
 
 import torch
 
+
 # Ensure project root is on sys.path so nvsubquadratic.* is importable.
 _PROJECT_ROOT = Path(__file__).resolve().parent.parent
 if str(_PROJECT_ROOT) not in sys.path:
     sys.path.insert(0, str(_PROJECT_ROOT))
 
-from nvsubquadratic.lazy_config import LazyConfig, instantiate  # noqa: E402
-from nvsubquadratic.modules.ckconv_nd import CKConvND  # noqa: E402
-from nvsubquadratic.modules.grn import GlobalResponseNorm  # noqa: E402
-from nvsubquadratic.modules.hyena_nd import Hyena  # noqa: E402
-from nvsubquadratic.modules.kernels_nd import (  # noqa: E402
+from nvsubquadratic.lazy_config import LazyConfig, instantiate
+from nvsubquadratic.modules.ckconv_nd import CKConvND
+from nvsubquadratic.modules.grn import GlobalResponseNorm
+from nvsubquadratic.modules.hyena_nd import Hyena
+from nvsubquadratic.modules.kernels_nd import (
     BlockDiagonalLearnableOmegaSIRENKernelND,
     BlockDiagonalMultiOmegaSIRENKernelND,
     SIRENKernelND,
 )
-from nvsubquadratic.modules.masks_nd import (  # noqa: E402
+from nvsubquadratic.modules.masks_nd import (
     BlockAlignedGaussianModulationND,
     GaussianModulationND,
 )
-from nvsubquadratic.modules.mlp import MLP  # noqa: E402
-from nvsubquadratic.modules.rms_norm import RMSNorm  # noqa: E402
-from nvsubquadratic.modules.sequence_mixer import QKVSequenceMixer  # noqa: E402
-from nvsubquadratic.modules.vit5_attention import ViT5Attention  # noqa: E402
-from nvsubquadratic.modules.vit5_hyena_adapter import ViT5HyenaAdapter  # noqa: E402
-from nvsubquadratic.modules.vit5_residual_block import ViT5ResidualBlock  # noqa: E402
-from nvsubquadratic.networks.vit5_classification import ViT5ClassificationNet  # noqa: E402
-from nvsubquadratic.utils.init import (  # noqa: E402
+from nvsubquadratic.modules.mlp import MLP
+from nvsubquadratic.modules.rms_norm import RMSNorm
+from nvsubquadratic.modules.sequence_mixer import QKVSequenceMixer
+from nvsubquadratic.modules.vit5_attention import ViT5Attention
+from nvsubquadratic.modules.vit5_hyena_adapter import ViT5HyenaAdapter
+from nvsubquadratic.modules.vit5_residual_block import ViT5ResidualBlock
+from nvsubquadratic.networks.vit5_classification import ViT5ClassificationNet
+from nvsubquadratic.utils.init import (
     trunc_normal_init,
     trunc_normal_init_factory,
 )
-from nvsubquadratic.utils.qk_norm import L2Norm  # noqa: E402
+from nvsubquadratic.utils.qk_norm import L2Norm
 
 
 # ─── Mirrored constants ───────────────────────────────────────────────────────
@@ -573,7 +574,7 @@ def main() -> None:
                     fft_backend=args.fft_backend,
                 )
             )
-        except Exception as exc:  # noqa: BLE001
+        except Exception as exc:
             print(f"[error] {name} failed: {exc!r}", flush=True)
             results.append(
                 {

--- a/scripts/benchmark_patch_size_2d.py
+++ b/scripts/benchmark_patch_size_2d.py
@@ -1,0 +1,474 @@
+"""Forward-time vs patch-size benchmark for the 2D residual-net mixers.
+
+Times the forward pass of a small 2D ``ResidualNetwork`` with the QKV
+sequence mixer swapped between attention, Hyena, and Mamba2.  For each
+patch size ``p`` in ``--patch-sizes`` we feed an input image of shape
+``(batch, H//p, W//p, in_channels)`` — i.e. patching reduces the
+per-axis token count by ``p``, so the total sequence length scales as
+``p^-2``.
+
+Mirrors the configuration of the EMNIST spatial-recall-2D mask-selection
+XS configs:
+
+    examples/spatial_recall_2d/emnist_regression_mask_selection/ccnn_attn_xs.py
+    examples/spatial_recall_2d/emnist_regression_mask_selection/ccnn_hyena_xs.py
+    examples/spatial_recall_2d/emnist_regression_mask_selection/ccnn_mamba_xs.py
+
+Default canvas (H=W=64) is the same as those configs; ``hidden_dim``
+is taken per-mixer to match (160 for attention/Hyena, 96 for Mamba).
+
+Local sanity-check (RTX-class GPU)::
+
+    python scripts/benchmark_patch_size_2d.py \\
+        --batch-size 1 --no-compile --fft-backend torch_fft \\
+        --patch-sizes 2 4 8 --num-warmup 2 --num-iters 5
+
+H100 production run (matching the throughput script)::
+
+    python scripts/benchmark_patch_size_2d.py
+"""
+
+from __future__ import annotations
+
+import argparse
+import gc
+import sys
+import time
+from pathlib import Path
+from typing import Callable
+
+import torch
+
+_PROJECT_ROOT = Path(__file__).resolve().parent.parent
+if str(_PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(_PROJECT_ROOT))
+
+from nvsubquadratic.lazy_config import LazyConfig, instantiate  # noqa: E402
+from nvsubquadratic.modules.attention import Attention  # noqa: E402
+from nvsubquadratic.modules.ckconv_nd import CKConvND  # noqa: E402
+from nvsubquadratic.modules.hyena_nd import Hyena  # noqa: E402
+from nvsubquadratic.modules.kernels_nd import SIRENKernelND  # noqa: E402
+from nvsubquadratic.modules.mlp import MLP  # noqa: E402
+from nvsubquadratic.modules.residual_block import ResidualBlock  # noqa: E402
+from nvsubquadratic.modules.sequence_mixer import QKVSequenceMixer  # noqa: E402
+from nvsubquadratic.networks.general_purpose_resnet import ResidualNetwork  # noqa: E402
+from nvsubquadratic.utils.init import (  # noqa: E402
+    partial_wang_init_fn_with_num_layers,
+    small_init,
+)
+
+
+# ─── Mirrored constants (spatial_recall_2d XS) ────────────────────────────────
+DATA_DIM = 2
+NUM_BLOCKS = 4
+IN_CHANNELS = 2
+OUT_CHANNELS = 1
+CANVAS_SIZE = 64
+
+# Per-mixer XS hidden_dim (matches the *_xs.py configs)
+HIDDEN_DIM_ATTN = 160
+HIDDEN_DIM_HYENA = 160
+HIDDEN_DIM_MAMBA = 96
+
+# SIREN kernel hyperparameters (mixer_defaults.get_hyena_mixer_cfg defaults)
+KERNEL_MLP_HIDDEN_DIM = 32
+KERNEL_NUM_LAYERS = 3
+KERNEL_EMBEDDING_DIM = 32
+KERNEL_OMEGA_0 = 10.0
+KERNEL_HIDDEN_OMEGA_0 = 1.0
+
+# Attention defaults (ccnn_attn_xs)
+ATTN_NUM_HEADS = 8
+# RoPE is disabled here: it would need ``rope_spatial_dims`` baked in at
+# construction time, but the patch sweep changes spatial dims at every
+# point.  Step-time impact of RoPE itself is small relative to the QKV
+# matmul + attention cost, so this is a fair stand-in.
+ATTN_USE_ROPE = False
+
+# Mamba defaults (ccnn_mamba_xs)
+MAMBA_HEADDIM = 32
+MAMBA_EXPAND = 2
+MAMBA_BIDIRECTIONAL = True
+
+
+# ─── Mixer config builders (concrete — no OmegaConf interpolation) ────────────
+
+
+def _hyena_mixer_cfg(hidden_dim: int, fft_backend: str) -> LazyConfig:
+    return LazyConfig(QKVSequenceMixer)(
+        hidden_dim=hidden_dim,
+        mixer_cfg=LazyConfig(Hyena)(
+            global_conv_cfg=LazyConfig(CKConvND)(
+                data_dim=DATA_DIM,
+                hidden_dim=hidden_dim,
+                kernel_cfg=LazyConfig(SIRENKernelND)(
+                    data_dim=DATA_DIM,
+                    out_dim=hidden_dim,
+                    mlp_hidden_dim=KERNEL_MLP_HIDDEN_DIM,
+                    num_layers=KERNEL_NUM_LAYERS,
+                    embedding_dim=KERNEL_EMBEDDING_DIM,
+                    omega_0=KERNEL_OMEGA_0,
+                    L_cache=CANVAS_SIZE,
+                    use_bias=True,
+                    hidden_omega_0=KERNEL_HIDDEN_OMEGA_0,
+                ),
+                mask_cfg=LazyConfig(torch.nn.Identity)(),
+                grid_type="double",
+                fft_padding="zero",
+                fft_backend=fft_backend,
+            ),
+            short_conv_cfg=LazyConfig(torch.nn.Conv2d)(
+                in_channels=3 * hidden_dim,
+                out_channels=3 * hidden_dim,
+                kernel_size=3,
+                groups=3 * hidden_dim,
+                padding=1,
+                bias=False,
+            ),
+            gate_nonlinear_cfg=LazyConfig(torch.nn.Identity)(),
+            pixelhyena_norm_cfg=LazyConfig(torch.nn.LayerNorm)(normalized_shape=hidden_dim),
+            qk_norm_cfg=None,
+            use_rope=False,
+            rope_base=10000.0,
+        ),
+        init_method_in=small_init,
+        init_method_out=LazyConfig(partial_wang_init_fn_with_num_layers)(num_layers=NUM_BLOCKS),
+    )
+
+
+def _attention_mixer_cfg(hidden_dim: int) -> LazyConfig:
+    return LazyConfig(QKVSequenceMixer)(
+        hidden_dim=hidden_dim,
+        mixer_cfg=LazyConfig(Attention)(
+            hidden_dim=hidden_dim,
+            num_heads=ATTN_NUM_HEADS,
+            apply_qk_norm=True,
+            use_rope=ATTN_USE_ROPE,
+            is_causal=False,
+            rope_base=10000.0,
+            attn_dropout=0.0,
+        ),
+        init_method_in=small_init,
+        init_method_out=LazyConfig(partial_wang_init_fn_with_num_layers)(num_layers=NUM_BLOCKS),
+    )
+
+
+def _mamba_mixer_cfg(hidden_dim: int) -> LazyConfig:
+    from mamba_ssm import Mamba2
+
+    from nvsubquadratic.modules.mamba_nd import Mamba as MambaNDMixer
+
+    return LazyConfig(MambaNDMixer)(
+        mamba_layer_cfg=LazyConfig(Mamba2)(
+            d_model=hidden_dim,
+            headdim=MAMBA_HEADDIM,
+            expand=MAMBA_EXPAND,
+        ),
+        bidirectional=MAMBA_BIDIRECTIONAL,
+    )
+
+
+# ─── Network builder ──────────────────────────────────────────────────────────
+
+
+def build_network(mixer_cfg: LazyConfig, hidden_dim: int) -> LazyConfig:
+    """Replicates spatial_recall_2d/base_config.base_experiment_config network."""
+    return LazyConfig(ResidualNetwork)(
+        in_channels=IN_CHANNELS,
+        out_channels=OUT_CHANNELS,
+        num_blocks=NUM_BLOCKS,
+        hidden_dim=hidden_dim,
+        data_dim=DATA_DIM,
+        in_proj_cfg=LazyConfig(torch.nn.Linear)(in_features=IN_CHANNELS, out_features=hidden_dim),
+        out_proj_cfg=LazyConfig(torch.nn.Linear)(in_features=hidden_dim, out_features=OUT_CHANNELS),
+        norm_cfg=LazyConfig(torch.nn.LayerNorm)(normalized_shape=hidden_dim),
+        block_cfg=LazyConfig(ResidualBlock)(
+            sequence_mixer_cfg=mixer_cfg,
+            sequence_mixer_norm_cfg=LazyConfig(torch.nn.LayerNorm)(normalized_shape=hidden_dim),
+            condition_mixer_cfg=LazyConfig(torch.nn.Identity)(),
+            condition_mixer_norm_cfg=LazyConfig(torch.nn.Identity)(),
+            mlp_cfg=LazyConfig(MLP)(
+                dim=hidden_dim,
+                activation="glu",
+                expansion_factor=1.0,
+                dropout_cfg=LazyConfig(torch.nn.Dropout)(p=0.0),
+                init_method_in=small_init,
+                init_method_out=LazyConfig(partial_wang_init_fn_with_num_layers)(num_layers=NUM_BLOCKS),
+            ),
+            mlp_norm_cfg=LazyConfig(torch.nn.LayerNorm)(normalized_shape=hidden_dim),
+            dropout_cfg=LazyConfig(torch.nn.Dropout)(p=0.0),
+        ),
+        dropout_in_cfg=LazyConfig(torch.nn.Dropout)(p=0.0),
+        target_size=None,
+    )
+
+
+# ─── Mixer registry ───────────────────────────────────────────────────────────
+
+MIXERS: dict[str, tuple[int, Callable[[str], LazyConfig], bool]] = {
+    # name → (hidden_dim, mixer_cfg_builder(fft_backend), needs_fft_backend)
+    "attention": (HIDDEN_DIM_ATTN, lambda fft: _attention_mixer_cfg(HIDDEN_DIM_ATTN), False),
+    "hyena": (HIDDEN_DIM_HYENA, lambda fft: _hyena_mixer_cfg(HIDDEN_DIM_HYENA, fft), True),
+    "mamba": (HIDDEN_DIM_MAMBA, lambda fft: _mamba_mixer_cfg(HIDDEN_DIM_MAMBA), False),
+}
+
+
+# ─── Benchmarking ─────────────────────────────────────────────────────────────
+
+
+def _input_shape_for(patch: int) -> tuple[int, int]:
+    """Return (H, W) after patching by ``patch`` along every spatial axis."""
+    if CANVAS_SIZE % patch != 0:
+        raise ValueError(
+            f"patch_size={patch} does not evenly divide canvas (H=W={CANVAS_SIZE})."
+        )
+    return (CANVAS_SIZE // patch, CANVAS_SIZE // patch)
+
+
+def _make_inputs(batch: int, patch: int, device: torch.device) -> dict[str, torch.Tensor]:
+    H, W = _input_shape_for(patch)
+    x = torch.randn(batch, H, W, IN_CHANNELS, device=device, dtype=torch.float32)
+    c = torch.zeros(batch, H, W, 0, device=device, dtype=torch.float32)
+    return {"input": x, "condition": c}
+
+
+def time_forward(
+    mixer_name: str,
+    patch: int,
+    *,
+    batch_size: int,
+    dtype: torch.dtype,
+    num_warmup: int,
+    num_iters: int,
+    compile_mode: str | None,
+    fft_backend: str,
+    device: torch.device,
+) -> tuple[float, float]:
+    """Returns ``(ms_per_batch, peak_mem_gb)``."""
+    hidden_dim, build_mixer_cfg, has_fft = MIXERS[mixer_name]
+
+    if has_fft and compile_mode is not None:
+        import nvsubquadratic.ops.fftconv as _fftconv
+
+        _fftconv.COMPILE_COMPATIBLE = True
+
+    network = instantiate(build_network(build_mixer_cfg(fft_backend), hidden_dim)).to(device).eval()
+
+    if compile_mode is not None:
+        network = torch.compile(network, mode=compile_mode)
+
+    inputs = _make_inputs(batch_size, patch, device)
+    torch.cuda.reset_peak_memory_stats(device)
+
+    with torch.inference_mode(), torch.autocast("cuda", dtype=dtype):
+        for _ in range(num_warmup):
+            _ = network(inputs)
+    torch.cuda.synchronize(device)
+
+    start = torch.cuda.Event(enable_timing=True)
+    end = torch.cuda.Event(enable_timing=True)
+    torch.cuda.synchronize(device)
+    start.record()
+    with torch.inference_mode(), torch.autocast("cuda", dtype=dtype):
+        for _ in range(num_iters):
+            _ = network(inputs)
+    end.record()
+    torch.cuda.synchronize(device)
+
+    ms_per_batch = start.elapsed_time(end) / num_iters
+    peak_mem_gb = torch.cuda.max_memory_allocated(device) / (1024**3)
+
+    del network, inputs
+    gc.collect()
+    torch.cuda.empty_cache()
+    if hasattr(torch, "_dynamo"):
+        torch._dynamo.reset()
+
+    return ms_per_batch, peak_mem_gb
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument(
+        "--patch-sizes",
+        nargs="+",
+        type=int,
+        default=[1, 2, 4, 8],
+        help="Patch sizes to sweep. Each axis is divided by the patch size, "
+        "so total seq_len scales as p^-2 in 2D.",
+    )
+    parser.add_argument(
+        "--mixers",
+        nargs="+",
+        choices=sorted(MIXERS.keys()),
+        default=sorted(MIXERS.keys()),
+        help="Subset of mixers to benchmark.",
+    )
+    parser.add_argument("--batch-size", type=int, default=4, help="Batch size for the timed forward pass.")
+    parser.add_argument("--num-warmup", type=int, default=10, help="Warmup iterations (also covers compile).")
+    parser.add_argument("--num-iters", type=int, default=30, help="Timed iterations.")
+    parser.add_argument(
+        "--dtype",
+        choices=["bf16", "fp16", "fp32"],
+        default="bf16",
+        help="Autocast dtype.",
+    )
+    parser.add_argument(
+        "--compile-mode",
+        type=str,
+        default="max-autotune-no-cudagraphs",
+        help="torch.compile mode (matches the training configs). Use --no-compile to disable.",
+    )
+    parser.add_argument("--no-compile", action="store_true", help="Disable torch.compile entirely.")
+    parser.add_argument(
+        "--fft-backend",
+        choices=["torch_fft", "subq_ops"],
+        default="subq_ops",
+        help="FFT conv backend for Hyena. Use 'torch_fft' on hosts without the subq_ops CUDA kernels.",
+    )
+    parser.add_argument(
+        "--output",
+        type=str,
+        default="patch_size_step_time.png",
+        help="Output figure path (PNG).",
+    )
+    parser.add_argument(
+        "--normalize",
+        choices=["per-mixer-min", "global-min", "none"],
+        default="per-mixer-min",
+        help="How to normalize step time for the relative-time plot. "
+        "'per-mixer-min' divides each mixer by its own min time (rightmost point = 1). "
+        "'global-min' divides every series by the global min. "
+        "'none' plots absolute ms.",
+    )
+    args = parser.parse_args()
+
+    if not torch.cuda.is_available():
+        raise SystemExit("CUDA device required for forward-time benchmark.")
+    device = torch.device("cuda")
+    torch.backends.cudnn.benchmark = True
+    torch.set_float32_matmul_precision("high")
+
+    dtype_map = {"bf16": torch.bfloat16, "fp16": torch.float16, "fp32": torch.float32}
+    dtype = dtype_map[args.dtype]
+    compile_mode = None if args.no_compile else args.compile_mode
+
+    print(f"Device: {torch.cuda.get_device_name(device)}")
+    print(
+        f"Settings: batch_size={args.batch_size} dtype={args.dtype} compile={compile_mode} "
+        f"fft_backend={args.fft_backend} warmup={args.num_warmup} timed={args.num_iters}"
+    )
+    print(f"Mixers: {args.mixers}    Patch sizes: {args.patch_sizes}")
+
+    # Validate patch sizes against canvas
+    for p in args.patch_sizes:
+        try:
+            _input_shape_for(p)
+        except ValueError as e:
+            raise SystemExit(str(e))
+
+    results: dict[str, dict[int, dict[str, float]]] = {m: {} for m in args.mixers}
+
+    for mixer in args.mixers:
+        for patch in args.patch_sizes:
+            H, W = _input_shape_for(patch)
+            seq_len = H * W
+            label = f"[{mixer:>9s}  patch={patch}  shape=({H},{W})  N={seq_len}]"
+            print(f"\n{label}", flush=True)
+            t0 = time.perf_counter()
+            try:
+                ms, mem = time_forward(
+                    mixer,
+                    patch,
+                    batch_size=args.batch_size,
+                    dtype=dtype,
+                    num_warmup=args.num_warmup,
+                    num_iters=args.num_iters,
+                    compile_mode=compile_mode,
+                    fft_backend=args.fft_backend,
+                    device=device,
+                )
+                wall = time.perf_counter() - t0
+                print(
+                    f"   ms/batch = {ms:8.3f}  |  peak mem = {mem:5.2f} GB  |  wall = {wall:5.1f}s",
+                    flush=True,
+                )
+                results[mixer][patch] = {"ms": ms, "mem_gb": mem}
+            except Exception as exc:  # noqa: BLE001
+                print(f"   [error] {exc!r}", flush=True)
+                results[mixer][patch] = {"ms": float("nan"), "mem_gb": float("nan")}
+
+    # ── Summary table ────────────────────────────────────────────────────────
+    print(f"\n{'=' * 72}")
+    print("Forward-time summary (lower is better, ms per batch)")
+    print(f"{'=' * 72}")
+    header = f"{'Patch':>6s}  " + "  ".join(f"{m:>14s}" for m in args.mixers)
+    print(header)
+    print("-" * len(header))
+    for p in args.patch_sizes:
+        row = f"{p:>6d}  "
+        for m in args.mixers:
+            ms = results[m].get(p, {}).get("ms", float("nan"))
+            row += f"{ms:>14.3f}  "
+        print(row.rstrip())
+
+    # ── Plot ──────────────────────────────────────────────────────────────────
+    try:
+        import matplotlib
+
+        matplotlib.use("Agg")
+        import matplotlib.pyplot as plt
+    except ImportError:
+        print("\n[plot] matplotlib not available — skipping figure.", flush=True)
+        return
+
+    if args.normalize == "global-min":
+        all_ms = [results[m][p]["ms"] for m in args.mixers for p in args.patch_sizes]
+        finite = [v for v in all_ms if v == v]  # NaN-safe
+        norm = min(finite) if finite else 1.0
+        ylabel = "Step Time (relative to global min)"
+    elif args.normalize == "per-mixer-min":
+        norm = None  # per-curve
+        ylabel = "Step Time (relative)"
+    else:
+        norm = 1.0
+        ylabel = "Step Time (ms / batch)"
+
+    fig, ax = plt.subplots(figsize=(6.0, 4.5))
+    markers = {"attention": "s", "hyena": "o", "mamba": "^"}
+    linestyles = {"attention": "--", "hyena": "-", "mamba": ":"}
+
+    for m in args.mixers:
+        xs = args.patch_sizes
+        ys = [results[m][p]["ms"] for p in xs]
+        if args.normalize == "per-mixer-min":
+            finite = [v for v in ys if v == v]
+            denom = min(finite) if finite else 1.0
+            ys = [v / denom for v in ys]
+        elif args.normalize == "global-min":
+            ys = [v / norm for v in ys]
+        ax.plot(
+            xs,
+            ys,
+            marker=markers.get(m, "o"),
+            linestyle=linestyles.get(m, "-"),
+            label=m.capitalize(),
+        )
+
+    ax.set_xlabel("Patch Size")
+    ax.set_ylabel(ylabel)
+    ax.set_title("Step Time vs. Patch Size (2D residual-net, mixer ablation)")
+    ax.set_xscale("log", base=2)
+    ax.set_xticks(args.patch_sizes)
+    ax.set_xticklabels([str(p) for p in args.patch_sizes])
+    ax.grid(alpha=0.3)
+    ax.legend()
+
+    fig.tight_layout()
+    out_path = Path(args.output)
+    fig.savefig(out_path, dpi=150)
+    print(f"\n[plot] saved {out_path.resolve()}", flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/benchmark_patch_size_2d.py
+++ b/scripts/benchmark_patch_size_2d.py
@@ -220,9 +220,7 @@ MIXERS: dict[str, tuple[int, Callable[[str], LazyConfig], bool]] = {
 def _input_shape_for(patch: int) -> tuple[int, int]:
     """Return (H, W) after patching by ``patch`` along every spatial axis."""
     if CANVAS_SIZE % patch != 0:
-        raise ValueError(
-            f"patch_size={patch} does not evenly divide canvas (H=W={CANVAS_SIZE})."
-        )
+        raise ValueError(f"patch_size={patch} does not evenly divide canvas (H=W={CANVAS_SIZE}).")
     return (CANVAS_SIZE // patch, CANVAS_SIZE // patch)
 
 
@@ -295,8 +293,7 @@ def main() -> None:
         nargs="+",
         type=int,
         default=[1, 2, 4, 8],
-        help="Patch sizes to sweep. Each axis is divided by the patch size, "
-        "so total seq_len scales as p^-2 in 2D.",
+        help="Patch sizes to sweep. Each axis is divided by the patch size, so total seq_len scales as p^-2 in 2D.",
     )
     parser.add_argument(
         "--mixers",

--- a/scripts/benchmark_patch_size_2d.py
+++ b/scripts/benchmark_patch_size_2d.py
@@ -39,20 +39,21 @@ from typing import Callable
 
 import torch
 
+
 _PROJECT_ROOT = Path(__file__).resolve().parent.parent
 if str(_PROJECT_ROOT) not in sys.path:
     sys.path.insert(0, str(_PROJECT_ROOT))
 
-from nvsubquadratic.lazy_config import LazyConfig, instantiate  # noqa: E402
-from nvsubquadratic.modules.attention import Attention  # noqa: E402
-from nvsubquadratic.modules.ckconv_nd import CKConvND  # noqa: E402
-from nvsubquadratic.modules.hyena_nd import Hyena  # noqa: E402
-from nvsubquadratic.modules.kernels_nd import SIRENKernelND  # noqa: E402
-from nvsubquadratic.modules.mlp import MLP  # noqa: E402
-from nvsubquadratic.modules.residual_block import ResidualBlock  # noqa: E402
-from nvsubquadratic.modules.sequence_mixer import QKVSequenceMixer  # noqa: E402
-from nvsubquadratic.networks.general_purpose_resnet import ResidualNetwork  # noqa: E402
-from nvsubquadratic.utils.init import (  # noqa: E402
+from nvsubquadratic.lazy_config import LazyConfig, instantiate
+from nvsubquadratic.modules.attention import Attention
+from nvsubquadratic.modules.ckconv_nd import CKConvND
+from nvsubquadratic.modules.hyena_nd import Hyena
+from nvsubquadratic.modules.kernels_nd import SIRENKernelND
+from nvsubquadratic.modules.mlp import MLP
+from nvsubquadratic.modules.residual_block import ResidualBlock
+from nvsubquadratic.modules.sequence_mixer import QKVSequenceMixer
+from nvsubquadratic.networks.general_purpose_resnet import ResidualNetwork
+from nvsubquadratic.utils.init import (
     partial_wang_init_fn_with_num_layers,
     small_init,
 )
@@ -394,7 +395,7 @@ def main() -> None:
                     flush=True,
                 )
                 results[mixer][patch] = {"ms": ms, "mem_gb": mem}
-            except Exception as exc:  # noqa: BLE001
+            except Exception as exc:
                 print(f"   [error] {exc!r}", flush=True)
                 results[mixer][patch] = {"ms": float("nan"), "mem_gb": float("nan")}
 

--- a/scripts/visualize_patch_size_throughput.py
+++ b/scripts/visualize_patch_size_throughput.py
@@ -22,22 +22,22 @@ import matplotlib.pyplot as plt
 import numpy as np
 
 
-matplotlib.rcParams['pdf.fonttype'] = 42
-matplotlib.rcParams['ps.fonttype'] = 42
+matplotlib.rcParams["pdf.fonttype"] = 42
+matplotlib.rcParams["ps.fonttype"] = 42
 
 
 # (patch, seq_len, attention, hyena, mamba) — ms / batch, lower is better
 DATA = [
     (1, 4096, 1.986, 1.550, 4.478),
     (2, 1024, 0.692, 1.502, 4.333),
-    (4,  256, 0.687, 1.552, 4.301),
-    (8,   64, 0.649, 1.372, 4.283),
+    (4, 256, 0.687, 1.552, 4.301),
+    (8, 64, 0.649, 1.372, 4.283),
 ]
 
 SERIES = {
     "Attention": {"idx": 2, "color": "#3B6FB6", "marker": "o"},
-    "Hyena":     {"idx": 3, "color": "#C0392B", "marker": "s"},
-    "Mamba2":    {"idx": 4, "color": "#7A8B3C", "marker": "D", "linestyle": "--"},
+    "Hyena": {"idx": 3, "color": "#C0392B", "marker": "s"},
+    "Mamba2": {"idx": 4, "color": "#7A8B3C", "marker": "D", "linestyle": "--"},
 }
 
 
@@ -48,20 +48,22 @@ def _format_seq(n: int) -> str:
 
 
 def make_plot(out_path: Path) -> None:
-    plt.rcParams.update({
-        "font.family": "serif",
-        "font.size": 11,
-        "axes.titlesize": 12,
-        "axes.titleweight": "bold",
-        "axes.labelsize": 11,
-        "xtick.labelsize": 9,
-        "ytick.labelsize": 9,
-        "axes.spines.top": False,
-        "axes.spines.right": False,
-        "axes.linewidth": 0.8,
-        "xtick.major.width": 0.8,
-        "ytick.major.width": 0.8,
-    })
+    plt.rcParams.update(
+        {
+            "font.family": "serif",
+            "font.size": 11,
+            "axes.titlesize": 12,
+            "axes.titleweight": "bold",
+            "axes.labelsize": 11,
+            "xtick.labelsize": 9,
+            "ytick.labelsize": 9,
+            "axes.spines.top": False,
+            "axes.spines.right": False,
+            "axes.linewidth": 0.8,
+            "xtick.major.width": 0.8,
+            "ytick.major.width": 0.8,
+        }
+    )
 
     fig, ax = plt.subplots(figsize=(2.6, 2.4), constrained_layout=True)
 
@@ -72,7 +74,8 @@ def make_plot(out_path: Path) -> None:
     for label, cfg in SERIES.items():
         y = np.array([row[cfg["idx"]] for row in DATA])[sort_idx]
         ax.plot(
-            x, y,
+            x,
+            y,
             color=cfg["color"],
             marker=cfg["marker"],
             linestyle=cfg.get("linestyle", "-"),

--- a/scripts/visualize_patch_size_throughput.py
+++ b/scripts/visualize_patch_size_throughput.py
@@ -1,0 +1,127 @@
+"""Plot patch-size / sequence-length throughput results in paper style.
+
+Renders the ms/batch numbers from the H100 patch-size benchmark
+(attention vs. hyena vs. mamba_ssm, batch=4, bf16, max-autotune) as a
+single small-multiple-style panel matching the figure layout used in
+the manuscript (see paper/ figs: bold title, scientific-notation y-axis,
+log-spaced sequence-length ticks, circle/square markers).
+
+Usage::
+
+    python scripts/visualize_patch_size_throughput.py \
+        --out throughput_benchmark/results/patch_size_step_time.png
+"""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+import matplotlib
+import matplotlib.pyplot as plt
+import numpy as np
+
+matplotlib.rcParams['pdf.fonttype'] = 42
+matplotlib.rcParams['ps.fonttype'] = 42
+
+
+# (patch, seq_len, attention, hyena, mamba) — ms / batch, lower is better
+DATA = [
+    (1, 4096, 1.986, 1.550, 4.478),
+    (2, 1024, 0.692, 1.502, 4.333),
+    (4,  256, 0.687, 1.552, 4.301),
+    (8,   64, 0.649, 1.372, 4.283),
+]
+
+SERIES = {
+    "Attention": {"idx": 2, "color": "#3B6FB6", "marker": "o"},
+    "Hyena":     {"idx": 3, "color": "#C0392B", "marker": "s"},
+    "Mamba2":    {"idx": 4, "color": "#7A8B3C", "marker": "D", "linestyle": "--"},
+}
+
+
+def _format_seq(n: int) -> str:
+    if n >= 1000:
+        return f"{round(n / 1024)}K" if n >= 1024 else f"{round(n / 1000)}K"
+    return str(n)
+
+
+def make_plot(out_path: Path) -> None:
+    plt.rcParams.update({
+        "font.family": "serif",
+        "font.size": 11,
+        "axes.titlesize": 12,
+        "axes.titleweight": "bold",
+        "axes.labelsize": 11,
+        "xtick.labelsize": 9,
+        "ytick.labelsize": 9,
+        "axes.spines.top": False,
+        "axes.spines.right": False,
+        "axes.linewidth": 0.8,
+        "xtick.major.width": 0.8,
+        "ytick.major.width": 0.8,
+    })
+
+    fig, ax = plt.subplots(figsize=(2.6, 2.4), constrained_layout=True)
+
+    seq_lens = np.array([row[1] for row in DATA])
+    sort_idx = np.argsort(seq_lens)
+    x = seq_lens[sort_idx]
+
+    for label, cfg in SERIES.items():
+        y = np.array([row[cfg["idx"]] for row in DATA])[sort_idx]
+        ax.plot(
+            x, y,
+            color=cfg["color"],
+            marker=cfg["marker"],
+            linestyle=cfg.get("linestyle", "-"),
+            linewidth=1.6,
+            markersize=5.5,
+            markeredgecolor="black",
+            markeredgewidth=0.5,
+            label=label,
+        )
+
+    ax.set_title("Patch-Size Throughput")
+    ax.set_xscale("log")
+    ax.set_xticks(x)
+    ax.set_xticklabels([_format_seq(s) for s in x])
+    ax.minorticks_off()
+    ax.set_xlabel("Seq. length")
+    ax.set_ylabel("ms / batch")
+    ax.grid(True, axis="y", linestyle=":", linewidth=0.5, alpha=0.6)
+    ax.set_ylim(bottom=0)
+
+    ax.set_ylim(top=ax.get_ylim()[1] * 1.25)
+    ax.legend(
+        frameon=False,
+        fontsize=8,
+        loc="upper left",
+        handlelength=1.6,
+        borderaxespad=0.4,
+        ncol=3,
+        columnspacing=1.0,
+    )
+
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    fig.savefig(out_path, dpi=300, bbox_inches="tight")
+    pdf_path = out_path.with_suffix(".pdf")
+    fig.savefig(pdf_path, bbox_inches="tight")
+    plt.close(fig)
+    print(f"Saved: {out_path}")
+    print(f"Saved: {pdf_path}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--out",
+        type=Path,
+        default=Path("throughput_benchmark/results/patch_size_step_time.png"),
+    )
+    args = parser.parse_args()
+    make_plot(args.out)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/visualize_patch_size_throughput.py
+++ b/scripts/visualize_patch_size_throughput.py
@@ -21,6 +21,7 @@ import matplotlib
 import matplotlib.pyplot as plt
 import numpy as np
 
+
 matplotlib.rcParams['pdf.fonttype'] = 42
 matplotlib.rcParams['ps.fonttype'] = 42
 


### PR DESCRIPTION
Two standalone benchmark scripts for the dwromero/blockdiag-kernel work. Both build their networks directly from `nvsubquadratic` modules — **no apex / DALI / Lightning required** — and share the same plumbing (`--fft-backend`, `--no-compile`, default compile mode `max-autotune-no-cudagraphs`).

---

## 1. `scripts/benchmark_imagenet_throughput.py`

Single-GPU `imgs/s` benchmark for the four ImageNet-1k ViT-5 runs from this branch, comparable to **VMamba Table 1** ([arxiv:2401.10166](https://arxiv.org/pdf/2401.10166)).

### Models benchmarked

| Name | Layout | Top-1 (val / EMA) |
|---|---|---|
| `full_hyena_learnable_omega_blockdiag` | `H × 12` | 0.8362 / 0.8361 |
| `hhha_blockdiag` (3H:1A) | `HHHA × 3` | 0.8379 / 0.8380 |
| `attention_pretrain` (pure attn) | `A × 12` | 0.8393 / 0.8389 |
| `ha_blockdiag` (1H:1A) | `HA × 6` | 0.8404 / 0.8404 |

All ~22M params (ViT-S scale, hidden=384, patch=16, 224×224, 4 register tokens).

### Protocol (matches Swin / VMamba)
- 224×224 mock inputs, batch size 128, single H100, BF16 autocast
- `torch.inference_mode()` + `eval()`, `torch.compile(mode=\"max-autotune-no-cudagraphs\")`
- 30 warmup iterations (covers compile) + 50 timed iterations using `cuda.Event`
- Reports `imgs/s`, `ms/batch`, params, peak memory

### How to run on H100 (production / `subq_ops`)

```bash
# Default: bs=128, bf16, max-autotune-no-cudagraphs, fft_backend=subq_ops, all 4 models
python scripts/benchmark_imagenet_throughput.py

# Match a different VMamba column (e.g. bs=256)
python scripts/benchmark_imagenet_throughput.py --batch-size 256

# Subset by substring match
python scripts/benchmark_imagenet_throughput.py --models hhha attention
```

| Flag | Default | Notes |
|---|---|---|
| `--batch-size` | 128 | VMamba uses 128. |
| `--dtype` | `bf16` | `fp16` / `fp32` also available. |
| `--compile-mode` | `max-autotune-no-cudagraphs` | Matches training configs. Pass `--no-compile` to disable. |
| `--fft-backend` | `subq_ops` | Use `torch_fft` on hosts without the optimized CUDA kernels. |
| `--num-warmup` / `--num-iters` | 30 / 50 | Tune for tighter/looser timing windows. |
| `--models` | all 4 | Substring match (e.g. `--models attention hhha`). |

---

## 2. `scripts/benchmark_patch_size_2d.py`

Step-time vs patch-size sweep on the **2D spatial-recall residual-net** with the QKV sequence mixer swapped between **attention / Hyena / Mamba2**. Produces a figure (relative step time vs patch size) plus a numeric table.

### Setup (mirrors `examples/spatial_recall_2d/emnist_regression_mask_selection/ccnn_*_xs.py`)
- `ResidualNetwork`, 4 blocks, GLU MLP, LayerNorm, identity condition mixer
- canvas H=W=64; in_channels=2, out_channels=1
- per-mixer hidden_dim: attention 160, Hyena 160, Mamba2 96 (matches `ccnn_mamba_xs`)
- Attention: 8 heads, **RoPE off** — RoPE needs `rope_spatial_dims` baked in at construction, which doesn't compose with a patch sweep over varying spatial dims; the timing impact is small relative to QKV matmul + attention itself
- Hyena: SIREN kernel, identity mask
- Mamba2: bidirectional, headdim=32

### Patch axis semantics
Patch size `p` divides each spatial axis, so `seq_len ∝ p⁻²`:

| `p` | shape (H,W) | seq_len |
|---|---|---|
| 1 | (64, 64) | 4 096 |
| 2 | (32, 32) | 1 024 |
| 4 | (16, 16) | 256 |
| 8 | (8, 8) | 64 |

### How to run on H100 (production / `subq_ops`)

```bash
# Default: patch_sizes 1 2 4 8, all 3 mixers, bs=4, bf16,
#   compile=max-autotune-no-cudagraphs, fft_backend=subq_ops,
#   30 timed iters, saves patch_size_step_time.png
python scripts/benchmark_patch_size_2d.py
```

| Flag | Default | Notes |
|---|---|---|
| `--patch-sizes` | `1 2 4 8` | Each axis divided by `p`; must evenly divide H=W=64. |
| `--mixers` | `attention hyena mamba` | Subset of mixers to sweep. |
| `--batch-size` | 4 | Bump on H100; attention at p=1 has the tightest memory budget. |
| `--num-warmup` / `--num-iters` | 10 / 30 | |
| `--dtype` | `bf16` | |
| `--compile-mode` | `max-autotune-no-cudagraphs` | `--no-compile` to disable. |
| `--fft-backend` | `subq_ops` | `torch_fft` on hosts without the optimized kernels. |
| `--normalize` | `per-mixer-min` | `global-min` or `none` (absolute ms) also available. |
| `--output` | `patch_size_step_time.png` | PNG output path. |

### Outputs
1. Per-iteration log line (mixer / patch / shape / N / ms / peak mem / wall).
2. End-of-run summary table of `ms/batch` indexed by patch size × mixer.
3. PNG figure: relative step time vs patch size, log-2 x-axis.

---

## Test plan
- [x] `benchmark_imagenet_throughput.py` smoketested on RTX 3090 (`bs=2`, `--no-compile`, `--fft-backend torch_fft`, fp32 + bf16) — all four configs build, ~22 M params each.
- [x] `benchmark_patch_size_2d.py` smoketested on RTX 3090 (`bs=1`, `--no-compile`, `--fft-backend torch_fft`, `--patch-sizes 2 4 8`) — all three mixers run, table + figure produced.
- [ ] H100 run of `benchmark_imagenet_throughput.py` with defaults.
- [ ] H100 run of `benchmark_patch_size_2d.py` with defaults (full `1 2 4 8` sweep).

🤖 Generated with [Claude Code](https://claude.com/claude-code)