### PR TITLE
expose subq-ops kernels for 1D

### DIFF
--- a/docs-tracker.md
+++ b/docs-tracker.md
@@ -25,46 +25,48 @@ Work bottom-up: primitive ops → modules → networks → experiments.
 
 ### `nvsubquadratic/ops/` — FFT convolution primitives
 
-| File                       | Status | Notes                                                   |
-| -------------------------- | ------ | ------------------------------------------------------- |
-| `README.md`                | \[x\]  | Folder overview, decision tree, math primer (new file)  |
-| `fftconv.py`               | \[x\]  | Module + key per-fn docstrings rewritten with math      |
-| `circular_fftconv.py`      | \[x\]  | Already strong; left as-is                              |
-| `circular_fftconv_fp16.py` | \[x\]  | Already strong; relies on FP16_FFTCONV_DERIVATION.md    |
-| `fftconv_fp16.py`          | \[x\]  | Already adequate; left as-is                            |
-| `fftconv_multihead.py`     | \[x\]  | Module docstring expanded with multi-head/low-rank math |
-| `fftconv_chunked.py`       | \[x\]  | Already strong; left as-is                              |
-| `fftconv_custom.py`        | \[x\]  | Module docstring expanded with motivation               |
+| File                       | Status | Notes                                                                             |
+| -------------------------- | ------ | --------------------------------------------------------------------------------- |
+| `README.md`                | \[x\]  | Folder overview, decision tree, math primer (new file)                            |
+| `fftconv.py`               | \[x\]  | Module + key per-fn docstrings rewritten with math                                |
+| `circular_fftconv.py`      | \[x\]  | Already strong; left as-is                                                        |
+| `circular_fftconv_fp16.py` | \[x\]  | Already strong; relies on FP16_FFTCONV_DERIVATION.md                              |
+| `fftconv_fp16.py`          | \[x\]  | Already adequate; left as-is                                                      |
+| `fftconv_multihead.py`     | \[x\]  | Module docstring expanded with multi-head/low-rank math                           |
+| `fftconv_chunked.py`       | \[x\]  | Already strong; left as-is                                                        |
+| `fftconv_custom.py`        | \[x\]  | Module docstring expanded with motivation; 1D causal wrappers added in 1D PR      |
+| `causal_conv1d_custom.py`  | \[x\]  | New (1D PR): thin wrappers for direct `causal_conv1d` + fused `b2b_causal_conv1d` |
 
 ### `nvsubquadratic/modules/` — Building blocks
 
-| File                               | Status | Notes                                     |
-| ---------------------------------- | ------ | ----------------------------------------- |
-| `kernels_nd.py`                    | \[ \]  | Learned kernel parametrisation            |
-| `hyena_nd.py`                      | \[ \]  | Hyena operator (ND) — key paper component |
-| `ckconv_nd.py`                     | \[ \]  | CKConv (ND)                               |
-| `ckconv_multihead_nd.py`           | \[ \]  | Multi-head CKConv                         |
-| `mamba_nd.py`                      | \[ \]  | Mamba SSM (ND)                            |
-| `attention.py`                     | \[ \]  | Standard attention                        |
-| `vit5_attention.py`                | \[ \]  | ViT5 attention variant                    |
-| `vit5_hyena_adapter.py`            | \[ \]  | Hyena adapter for ViT5                    |
-| `sequence_mixer.py`                | \[ \]  | Mixer abstraction                         |
-| `condition_mixer.py`               | \[ \]  | Conditioning mixer                        |
-| `residual_block.py`                | \[ \]  | Residual block                            |
-| `vit5_residual_block.py`           | \[ \]  | ViT5 residual block                       |
-| `patchify.py`                      | \[ \]  | Patch embedding                           |
-| `position_encoding.py`             | \[ \]  | Position encodings                        |
-| `masks_nd.py`                      | \[ \]  | ND masking utils                          |
-| `mlp.py`                           | \[ \]  | MLP block                                 |
-| `film.py`                          | \[ \]  | FiLM conditioning                         |
-| `grn.py`                           | \[ \]  | GRN normalisation                         |
-| `layer_scale.py`                   | \[ \]  | LayerScale                                |
-| `rms_norm.py`                      | \[ \]  | RMS normalisation                         |
-| `rms_norm_channel_first.py`        | \[ \]  | Channel-first RMS norm                    |
-| `drop_path.py`                     | \[ \]  | Stochastic depth                          |
-| `causal_conv1d.py`                 | \[ \]  | Causal 1D conv                            |
-| `schedulers.py`                    | \[ \]  | LR schedulers                             |
-| `distributed_depthwise_conv_nd.py` | \[ \]  | Distributed depthwise conv                |
+| File                               | Status | Notes                                                                                 |
+| ---------------------------------- | ------ | ------------------------------------------------------------------------------------- |
+| `kernels_nd.py`                    | \[ \]  | Learned kernel parametrisation                                                        |
+| `hyena_nd.py`                      | \[ \]  | Hyena operator (ND) — key paper component                                             |
+| `ckconv_nd.py`                     | \[ \]  | CKConv (ND)                                                                           |
+| `ckconv_multihead_nd.py`           | \[ \]  | Multi-head CKConv                                                                     |
+| `mamba_nd.py`                      | \[ \]  | Mamba SSM (ND)                                                                        |
+| `attention.py`                     | \[ \]  | Standard attention                                                                    |
+| `vit5_attention.py`                | \[ \]  | ViT5 attention variant                                                                |
+| `vit5_hyena_adapter.py`            | \[ \]  | Hyena adapter for ViT5                                                                |
+| `sequence_mixer.py`                | \[ \]  | Mixer abstraction                                                                     |
+| `condition_mixer.py`               | \[ \]  | Conditioning mixer                                                                    |
+| `residual_block.py`                | \[ \]  | Residual block                                                                        |
+| `vit5_residual_block.py`           | \[ \]  | ViT5 residual block                                                                   |
+| `patchify.py`                      | \[ \]  | Patch embedding                                                                       |
+| `position_encoding.py`             | \[ \]  | Position encodings                                                                    |
+| `masks_nd.py`                      | \[ \]  | ND masking utils                                                                      |
+| `mlp.py`                           | \[ \]  | MLP block                                                                             |
+| `film.py`                          | \[ \]  | FiLM conditioning                                                                     |
+| `grn.py`                           | \[ \]  | GRN normalisation                                                                     |
+| `layer_scale.py`                   | \[ \]  | LayerScale                                                                            |
+| `rms_norm.py`                      | \[ \]  | RMS normalisation                                                                     |
+| `rms_norm_channel_first.py`        | \[ \]  | Channel-first RMS norm                                                                |
+| `drop_path.py`                     | \[ \]  | Stochastic depth                                                                      |
+| `causal_conv1d.py`                 | \[ \]  | Causal 1D conv                                                                        |
+| `subq_ops_causal_conv1d.py`        | \[x\]  | New (1D PR): `nn.Conv1d`-compatible depthwise wrapper around `subq_ops.causal_conv1d` |
+| `schedulers.py`                    | \[ \]  | LR schedulers                                                                         |
+| `distributed_depthwise_conv_nd.py` | \[ \]  | Distributed depthwise conv                                                            |
 
 ### `nvsubquadratic/networks/` — Full architectures
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -34,6 +34,8 @@ Ops — FFT convolutions (CUDA-accelerated)
 -----------------------------------------
 
 Drop-in wrappers around the ``subquadratic_ops_torch`` fused CUDA kernels.
+2D non-causal and 1D causal long-conv variants share the same API as the
+fp32 reference ops above.
 
 .. autosummary::
    :toctree: generated/
@@ -42,6 +44,23 @@ Drop-in wrappers around the ``subquadratic_ops_torch`` fused CUDA kernels.
    ~ops.fftconv_custom.fftconv2d_blh
    ~ops.fftconv_custom.fftconv2d_bhl
    ~ops.fftconv_custom.fftconv2d_bhl_w_reshape
+   ~ops.fftconv_custom.causal_fftconv1d_blh
+   ~ops.fftconv_custom.causal_fftconv1d_bhl
+   ~ops.fftconv_custom.causal_fftconv1d_bhl_w_reshape
+
+Ops — Direct 1D causal convolutions (CUDA-accelerated)
+------------------------------------------------------
+
+Non-FFT CUDA kernels for short and fused 1D causal convolutions. Useful for
+small kernel sizes (where FFT overhead dominates) and as building blocks
+for fused Hyena variants.
+
+.. autosummary::
+   :toctree: generated/
+   :template: function_template.rst
+
+   ~ops.causal_conv1d_custom.causal_conv1d
+   ~ops.causal_conv1d_custom.b2b_causal_conv1d
 
 Ops — Circular FFT convolutions
 -------------------------------
@@ -107,3 +126,4 @@ Modules — Convolutions
    :template: class_template.rst
 
    ~modules.causal_conv1d.CausalConv1D
+   ~modules.subq_ops_causal_conv1d.SubqOpsCausalConv1d

--- a/docs/ops/README.md
+++ b/docs/ops/README.md
@@ -35,15 +35,16 @@ ______________________________________________________________________
 
 ## File map
 
-| File                                                                          | Precision | Conv type         | Channel mixing                       | When you'd reach for it                                                                                                                              |
-| ----------------------------------------------------------------------------- | --------- | ----------------- | ------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
-| [fftconv.py](../../nvsubquadratic/ops/fftconv.py)                             | fp32      | linear            | depthwise                            | The default. 1D/2D/3D, causal & non-causal.                                                                                                          |
-| [circular_fftconv.py](../../nvsubquadratic/ops/circular_fftconv.py)           | fp32      | circular          | depthwise                            | Periodic boundaries (e.g. PDEs, ARC grids), or when `K = N` so padding is wasteful.                                                                  |
-| [fftconv_fp16.py](../../nvsubquadratic/ops/fftconv_fp16.py)                   | fp16      | linear            | depthwise                            | Memory/throughput savings on power-of-2 spatial dims. Drop-in for `fftconv.py`.                                                                      |
-| [circular_fftconv_fp16.py](../../nvsubquadratic/ops/circular_fftconv_fp16.py) | fp16      | circular          | depthwise                            | Same as above for the circular case. Uses **dual mean-centering** for fp16 stability — see [FP16_FFTCONV_DERIVATION.md](FP16_FFTCONV_DERIVATION.md). |
-| [fftconv_chunked.py](../../nvsubquadratic/ops/fftconv_chunked.py)             | fp32      | linear            | depthwise                            | Memory-constrained training; processes channels in chunks. Has a global flag so models can opt in transparently.                                     |
-| [fftconv_multihead.py](../../nvsubquadratic/ops/fftconv_multihead.py)         | fp32      | linear & circular | dense within head, optional low-rank | Multi-head FFT conv — channel mixing inside each head, in the spirit of multi-head attention.                                                        |
-| [fftconv_custom.py](../../nvsubquadratic/ops/fftconv_custom.py)               | fp32      | linear            | depthwise                            | Wraps an optional fused CUDA kernel (`subquadratic_ops_torch.fft_conv2d`) behind the same API as `fftconv.py`.                                       |
+| File                                                                          | Precision | Conv type         | Channel mixing                       | When you'd reach for it                                                                                                                                                                               |
+| ----------------------------------------------------------------------------- | --------- | ----------------- | ------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [fftconv.py](../../nvsubquadratic/ops/fftconv.py)                             | fp32      | linear            | depthwise                            | The default. 1D/2D/3D, causal & non-causal.                                                                                                                                                           |
+| [circular_fftconv.py](../../nvsubquadratic/ops/circular_fftconv.py)           | fp32      | circular          | depthwise                            | Periodic boundaries (e.g. PDEs, ARC grids), or when `K = N` so padding is wasteful.                                                                                                                   |
+| [fftconv_fp16.py](../../nvsubquadratic/ops/fftconv_fp16.py)                   | fp16      | linear            | depthwise                            | Memory/throughput savings on power-of-2 spatial dims. Drop-in for `fftconv.py`.                                                                                                                       |
+| [circular_fftconv_fp16.py](../../nvsubquadratic/ops/circular_fftconv_fp16.py) | fp16      | circular          | depthwise                            | Same as above for the circular case. Uses **dual mean-centering** for fp16 stability — see [FP16_FFTCONV_DERIVATION.md](FP16_FFTCONV_DERIVATION.md).                                                  |
+| [fftconv_chunked.py](../../nvsubquadratic/ops/fftconv_chunked.py)             | fp32      | linear            | depthwise                            | Memory-constrained training; processes channels in chunks. Has a global flag so models can opt in transparently.                                                                                      |
+| [fftconv_multihead.py](../../nvsubquadratic/ops/fftconv_multihead.py)         | fp32      | linear & circular | dense within head, optional low-rank | Multi-head FFT conv — channel mixing inside each head, in the spirit of multi-head attention.                                                                                                         |
+| [fftconv_custom.py](../../nvsubquadratic/ops/fftconv_custom.py)               | fp32      | linear            | depthwise                            | Wraps optional fused CUDA kernels (`subquadratic_ops_torch.fft_conv2d` for 2D non-causal, `fft_causal_conv1d` for 1D causal) behind the same API as `fftconv.py`.                                     |
+| [causal_conv1d_custom.py](../../nvsubquadratic/ops/causal_conv1d_custom.py)   | fp32      | direct causal     | depthwise                            | Non-FFT 1D causal kernels (`causal_conv1d` short conv, `b2b_causal_conv1d` fused proj-gate-mixer-gate). Use for kernels short enough that FFT overhead dominates, or as a fused-Hyena building block. |
 
 `FP16_FFTCONV_DERIVATION.md` contains the full derivation of the numerically stable fp16 circular conv (dual mean-centering + inclusion-exclusion geometric correction). Read it if you are touching the fp16 path or want to understand the math behind those `T1, T2, T3, T4` terms in the code.
 
@@ -67,6 +68,8 @@ Every function name encodes its contract:
 | `_chunked`         | Processes channels in groups to reduce peak GPU memory.                                                                                        |
 
 So `causal_fftconv1d_fp32_bhl_w_reshape` is: causal 1D FFT conv, fp32 internal, accepts channels-last input, internally uses the channels-first kernel.
+
+The CUDA-accelerated wrappers in `fftconv_custom.py` drop the `_fp32_` / `_fp16_` token because the underlying kernel manages its own precision internally — so the same name in `fftconv_custom` is `causal_fftconv1d_bhl_w_reshape`. The direct-conv wrappers in `causal_conv1d_custom.py` (`causal_conv1d`, `b2b_causal_conv1d`) do not follow this scheme because they are thin pass-throughs to the upstream API; see their docstrings for shapes.
 
 ______________________________________________________________________
 
@@ -126,7 +129,9 @@ ______________________________________________________________________
 
 1. **Is there a fused CUDA kernel for my shape?**
 
-   - If you have `subquadratic_ops_torch` installed, `fftconv_custom.py` exposes its fused 2D kernel through the same API. Wire it in via the `fft_backend` config flag.
+   - 2D non-causal or 1D causal long-conv → `fftconv_custom.py` exposes the upstream fused FFT kernels (`fft_conv2d`, `fft_causal_conv1d`) through the same API. Wire in via the `fft_backend="subq_ops"` flag on `CKConvND`. The 1D path requires `data_dim=1, is_causal=True`; the 2D path requires `data_dim=2, is_causal=False`.
+   - 1D causal short conv (typical short_conv slot in a Hyena block) → `causal_conv1d_custom.py` exposes `causal_conv1d` directly, and `nvsubquadratic.modules.subq_ops_causal_conv1d.SubqOpsCausalConv1d` wraps it as a depthwise `nn.Conv1d`-compatible module.
+   - 1D causal fused proj+gate+mixer+gate block → `b2b_causal_conv1d` in `causal_conv1d_custom.py`. Not yet wired into a `Hyena` variant; exposed as a building block.
 
 ______________________________________________________________________
 

--- a/nvsubquadratic/modules/ckconv_nd.py
+++ b/nvsubquadratic/modules/ckconv_nd.py
@@ -344,7 +344,7 @@ class CKConvND(torch.nn.Module):
                 else:
                     self.fftconv_fn = causal_fftconv1d_bhl_w_reshape
                     self.fftconv_fn_bhl_input = causal_fftconv1d_bhl
-            else:
+            elif data_dim == 2:
                 from nvsubquadratic.ops.fftconv_custom import (
                     fftconv2d_bhl,
                     fftconv2d_bhl_chunked,
@@ -358,6 +358,11 @@ class CKConvND(torch.nn.Module):
                 else:
                     self.fftconv_fn = fftconv2d_bhl_w_reshape
                     self.fftconv_fn_bhl_input = fftconv2d_bhl
+            else:
+                raise AssertionError(
+                    f"fft_backend='subq_ops' dispatch reached unexpected data_dim={data_dim}; "
+                    "the constraint block above should have rejected this."
+                )
         else:
             # torch_fft backend: use lookup tables
             # Causal mode overrides fft_padding for 1D

--- a/nvsubquadratic/modules/ckconv_nd.py
+++ b/nvsubquadratic/modules/ckconv_nd.py
@@ -205,9 +205,13 @@ class CKConvND(torch.nn.Module):
             fft_backend: FFT convolution backend to use. ``'torch_fft'`` (default)
                 uses the torch.fft-based implementations. ``'subq_ops'`` uses the
                 optimized CUDA kernels from ``subquadratic_ops_torch``. The subq_ops
-                backend currently only supports 2D, zero-padded, non-causal
-                convolutions and does not support fp16 FFT. It supports chunked
-                convolutions via channel-wise chunking.
+                backend currently supports:
+                  - 2D, zero-padded, non-causal convolutions
+                  - 1D causal convolutions (``data_dim=1`` + ``is_causal=True``)
+                It does not support fp16 FFT. It supports chunked convolutions via
+                channel-wise chunking.  Per-sample (FiLM) weights are supported on
+                the 2D path only; the 1D causal CUDA kernel does not accept batched
+                weights.
         """
         assert grid_type in ["double", "single"], f"Invalid grid type: {grid_type}. Must be 'double' or 'single'."
         assert fft_padding in ["zero", "circular"], (
@@ -244,11 +248,23 @@ class CKConvND(torch.nn.Module):
 
         # subq_ops backend constraints
         if fft_backend == "subq_ops":
-            assert data_dim == 2, f"fft_backend='subq_ops' only supports 2D convolutions. Got data_dim={data_dim}."
-            assert fft_padding == "zero", (
-                f"fft_backend='subq_ops' only supports zero-padded convolutions. Got fft_padding='{fft_padding}'."
-            )
-            assert not is_causal, "fft_backend='subq_ops' does not support causal convolutions (causal is 1D only)."
+            if data_dim == 1:
+                assert is_causal, (
+                    "fft_backend='subq_ops' on 1D requires is_causal=True "
+                    "(no non-causal 1D CUDA kernel is wired). Got is_causal=False."
+                )
+            elif data_dim == 2:
+                assert not is_causal, (
+                    "fft_backend='subq_ops' on 2D does not support causal convolutions (causal is 1D only)."
+                )
+                assert fft_padding == "zero", (
+                    "fft_backend='subq_ops' on 2D only supports zero-padded convolutions. "
+                    f"Got fft_padding='{fft_padding}'."
+                )
+            else:
+                raise AssertionError(
+                    f"fft_backend='subq_ops' only supports data_dim in (1, 2). Got data_dim={data_dim}."
+                )
             assert not use_fp16_fft, (
                 "fft_backend='subq_ops' does not support fp16 FFT — the CUDA kernel "
                 "manages its own precision internally. Use use_fp16_fft=False."
@@ -313,19 +329,35 @@ class CKConvND(torch.nn.Module):
 
         # Select FFT convolution functions based on backend
         if fft_backend == "subq_ops":
-            from nvsubquadratic.ops.fftconv_custom import (
-                fftconv2d_bhl,
-                fftconv2d_bhl_chunked,
-                fftconv2d_bhl_w_reshape,
-                fftconv2d_bhl_w_reshape_chunked,
-            )
+            if data_dim == 1:
+                # 1D causal path (gated by the constraint block above).
+                from nvsubquadratic.ops.fftconv_custom import (
+                    causal_fftconv1d_bhl,
+                    causal_fftconv1d_bhl_chunked,
+                    causal_fftconv1d_bhl_w_reshape,
+                    causal_fftconv1d_bhl_w_reshape_chunked,
+                )
 
-            if use_chunked_fftconv:
-                self.fftconv_fn = fftconv2d_bhl_w_reshape_chunked
-                self.fftconv_fn_bhl_input = fftconv2d_bhl_chunked
+                if use_chunked_fftconv:
+                    self.fftconv_fn = causal_fftconv1d_bhl_w_reshape_chunked
+                    self.fftconv_fn_bhl_input = causal_fftconv1d_bhl_chunked
+                else:
+                    self.fftconv_fn = causal_fftconv1d_bhl_w_reshape
+                    self.fftconv_fn_bhl_input = causal_fftconv1d_bhl
             else:
-                self.fftconv_fn = fftconv2d_bhl_w_reshape
-                self.fftconv_fn_bhl_input = fftconv2d_bhl
+                from nvsubquadratic.ops.fftconv_custom import (
+                    fftconv2d_bhl,
+                    fftconv2d_bhl_chunked,
+                    fftconv2d_bhl_w_reshape,
+                    fftconv2d_bhl_w_reshape_chunked,
+                )
+
+                if use_chunked_fftconv:
+                    self.fftconv_fn = fftconv2d_bhl_w_reshape_chunked
+                    self.fftconv_fn_bhl_input = fftconv2d_bhl_chunked
+                else:
+                    self.fftconv_fn = fftconv2d_bhl_w_reshape
+                    self.fftconv_fn_bhl_input = fftconv2d_bhl
         else:
             # torch_fft backend: use lookup tables
             # Causal mode overrides fft_padding for 1D

--- a/nvsubquadratic/modules/subq_ops_causal_conv1d.py
+++ b/nvsubquadratic/modules/subq_ops_causal_conv1d.py
@@ -1,0 +1,70 @@
+# TODO: Add license header here
+
+"""Causal depthwise 1D convolution backed by the subq_ops CUDA kernel.
+
+Drop-in for ``torch.nn.Conv1d`` in Hyena's ``short_conv`` slot when the host
+is 1D autoregressive.  Subclasses :class:`torch.nn.Conv1d` so Hyena's
+``isinstance(..., torch.nn.Conv1d)`` check passes and parameter layout
+(``weight``/``bias``) matches the surrounding state-dict conventions.
+
+Constraints (asserted at construction):
+
+- ``groups == in_channels == out_channels`` (depthwise only — matches the
+  upstream kernel's ``[C, K]`` weight shape).
+- ``stride == 1`` and ``dilation == 1`` (the kernel does not support either).
+- ``padding`` is ignored; the kernel applies causal left-only padding internally.
+"""
+
+from __future__ import annotations
+
+import torch
+
+
+class SubqOpsCausalConv1d(torch.nn.Conv1d):
+    """Depthwise causal 1D conv using ``subquadratic_ops_torch.causal_conv1d``."""
+
+    def __init__(
+        self,
+        in_channels: int,
+        out_channels: int,
+        kernel_size: int,
+        *,
+        groups: int,
+        bias: bool = False,
+        activation: str = "identity",
+    ) -> None:
+        """Build a depthwise causal conv with optional SiLU activation.
+
+        Args:
+            in_channels: Channel count (must equal ``out_channels`` and ``groups``).
+            out_channels: Output channels (depthwise: same as ``in_channels``).
+            kernel_size: Causal kernel length.
+            groups: Must equal ``in_channels`` for depthwise layout.
+            bias: Whether to include a per-channel bias.
+            activation: ``"identity"`` or ``"silu"`` applied inside the CUDA kernel.
+        """
+        if not (groups == in_channels == out_channels):
+            raise ValueError(
+                "SubqOpsCausalConv1d is depthwise-only: groups must equal "
+                f"in_channels must equal out_channels.  Got groups={groups}, "
+                f"in_channels={in_channels}, out_channels={out_channels}."
+            )
+        if activation not in ("identity", "silu"):
+            raise ValueError(f"activation must be 'identity' or 'silu'. Got {activation!r}.")
+        super().__init__(
+            in_channels=in_channels,
+            out_channels=out_channels,
+            kernel_size=kernel_size,
+            groups=groups,
+            bias=bias,
+            padding=0,
+        )
+        self.activation = activation
+
+    def forward(self, input: torch.Tensor) -> torch.Tensor:  # type: ignore[override]
+        """Run causal depthwise conv; input shape ``[B, C, L]``."""
+        from nvsubquadratic.ops.causal_conv1d_custom import causal_conv1d
+
+        # nn.Conv1d depthwise weight is [C, 1, K]; upstream kernel expects [C, K].
+        weight_2d = self.weight.squeeze(1)
+        return causal_conv1d(input, weight_2d, self.bias, self.activation)

--- a/nvsubquadratic/ops/causal_conv1d_custom.py
+++ b/nvsubquadratic/ops/causal_conv1d_custom.py
@@ -1,0 +1,109 @@
+# TODO: Add license header here
+
+
+"""Drop-in wrappers around :mod:`subquadratic_ops_torch` 1D causal conv kernels.
+
+This module exposes thin Python wrappers around the upstream CUDA kernels for
+*direct* (non-FFT) 1D causal convolutions:
+
+- :func:`causal_conv1d` — depthwise causal 1D conv. Drop-in for the short
+  conv path in Hyena when the host is 1D autoregressive. For long-range
+  (kernel_size >= 128) prefer :mod:`fftconv_custom` instead.
+- :func:`b2b_causal_conv1d` — fused back-to-back kernel (projection conv,
+  pre-gate, mixer conv, post-gate). This is not a drop-in for any single
+  module in nvSubquadratic; it's a building block for future fused-Hyena
+  variants. Exposed here as a thin pass-through for callers that want to
+  experiment with it directly.
+
+.. note::
+   ``subquadratic_ops_torch`` is an **optional** dependency. Importing this
+   module always succeeds; a clear error is raised only when a function is
+   actually called without the package installed.
+"""
+
+from __future__ import annotations
+
+
+__all__ = [
+    "b2b_causal_conv1d",
+    "causal_conv1d",
+]
+
+import torch
+
+
+_causal_conv1d = None
+_b2b_causal_conv1d = None
+
+
+def _get_causal_conv1d():
+    global _causal_conv1d
+    if _causal_conv1d is None:
+        try:
+            from subquadratic_ops_torch.causal_conv1d import causal_conv1d as _fn
+
+            _causal_conv1d = _fn
+        except ImportError as exc:
+            raise ImportError(
+                "subquadratic_ops_torch is required for causal_conv1d. "
+                "Install it with: pip install subquadratic_ops_torch"
+            ) from exc
+    return _causal_conv1d
+
+
+def _get_b2b_causal_conv1d():
+    global _b2b_causal_conv1d
+    if _b2b_causal_conv1d is None:
+        try:
+            from subquadratic_ops_torch.b2b_causal_conv1d import b2b_causal_conv1d as _fn
+
+            _b2b_causal_conv1d = _fn
+        except ImportError as exc:
+            raise ImportError(
+                "subquadratic_ops_torch is required for b2b_causal_conv1d. "
+                "Install it with: pip install subquadratic_ops_torch"
+            ) from exc
+    return _b2b_causal_conv1d
+
+
+def causal_conv1d(
+    x: torch.Tensor,
+    weight: torch.Tensor,
+    bias: torch.Tensor | None = None,
+    activation: str = "identity",
+) -> torch.Tensor:
+    """Depthwise causal 1D conv via the subq_ops CUDA kernel.
+
+    Args:
+        x: Input tensor ``[B, C, L]``.
+        weight: Depthwise weight ``[C, K]``.
+        bias: Optional per-channel bias ``[C]``.
+        activation: ``"identity"`` (default) or ``"silu"``.
+
+    Returns:
+        Output tensor ``[B, C, L]`` (same shape as input).
+    """
+    return _get_causal_conv1d()(x, weight, bias, activation)
+
+
+def b2b_causal_conv1d(
+    x: torch.Tensor,
+    weight_proj: torch.Tensor,
+    weight_mixer: torch.Tensor,
+    skip_bias: torch.Tensor,
+) -> torch.Tensor:
+    """Back-to-back fused causal 1D conv via the subq_ops CUDA kernel.
+
+    Fused kernel performing projection conv, pre-gate, mixer conv with skip,
+    and post-gate.  See upstream docstring for the exact algorithm.
+
+    Args:
+        x: Input tensor ``[B, 3*C, L]``.
+        weight_proj: Projection weight ``[3*C, K]`` (depthwise).
+        weight_mixer: Mixer weight ``[C, K]`` (depthwise).
+        skip_bias: Skip-bias scalar-per-channel ``[C]``.
+
+    Returns:
+        Output tensor ``[B, C, L]``.
+    """
+    return _get_b2b_causal_conv1d()(x, weight_proj, weight_mixer, skip_bias)

--- a/nvsubquadratic/ops/fftconv_custom.py
+++ b/nvsubquadratic/ops/fftconv_custom.py
@@ -6,22 +6,35 @@ r"""Drop-in wrappers around the :mod:`subquadratic_ops_torch` custom CUDA FFT ke
 The pure-PyTorch FFT path in :mod:`nvsubquadratic.ops.fftconv` is general
 and correct, but each forward pass dispatches a chain of separate cuFFT,
 element-wise multiply, and inverse-cuFFT kernels. The
-:mod:`subquadratic_ops_torch` package ships a hand-written CUDA kernel
-(``fft_conv2d``) that fuses these stages into a single launch, eliminating
-intermediate tensor traffic and shaving wall-clock time on large 2D shapes.
+:mod:`subquadratic_ops_torch` package ships hand-written CUDA kernels
+(``fft_conv2d`` for 2D, ``fft_causal_conv1d`` for 1D causal) that fuse
+these stages into a single launch, eliminating intermediate tensor traffic
+and shaving wall-clock time on large shapes.
 
-This module exposes that kernel through the **same API** as the PyTorch
+This module exposes those kernels through the **same API** as the PyTorch
 operators in :mod:`nvsubquadratic.ops.fftconv`, so callers can switch
 backends (e.g. via a ``fft_backend`` config flag) without touching their
 model code.
 
 Functions provided
 ------------------
+2D (non-causal, zero-padded):
+
 - ``fftconv2d_bhl`` / ``fftconv2d_bhl_chunked``: BHL layout ``[B, H, X, Y]``.
 - ``fftconv2d_bhl_w_reshape`` / ``fftconv2d_bhl_w_reshape_chunked``: accepts
   BLH ``[B, X, Y, H]``, reshapes internally.
 - ``fftconv2d_blh`` / ``fftconv2d_blh_chunked``: aliases for the
   ``_w_reshape`` variants (BLH naming convention).
+
+1D causal:
+
+- ``causal_fftconv1d_bhl`` / ``causal_fftconv1d_bhl_chunked``: BHL layout
+  ``[B, H, L]``.
+- ``causal_fftconv1d_bhl_w_reshape`` /
+  ``causal_fftconv1d_bhl_w_reshape_chunked``: accepts BLH ``[B, L, H]``,
+  reshapes internally.
+- ``causal_fftconv1d_blh`` / ``causal_fftconv1d_blh_chunked``: aliases for
+  the ``_w_reshape`` variants.
 
 All functions accept any input dtype (bf16, fp16, fp32) and internally cast
 to fp32 for the CUDA kernel, returning the output in the original dtype.
@@ -43,6 +56,12 @@ from __future__ import annotations
 
 
 __all__ = [
+    "causal_fftconv1d_bhl",
+    "causal_fftconv1d_bhl_chunked",
+    "causal_fftconv1d_bhl_w_reshape",
+    "causal_fftconv1d_bhl_w_reshape_chunked",
+    "causal_fftconv1d_blh",
+    "causal_fftconv1d_blh_chunked",
     "fftconv2d_bhl",
     "fftconv2d_bhl_chunked",
     "fftconv2d_bhl_w_reshape",
@@ -227,3 +246,155 @@ def fftconv2d_blh_chunked(
 ) -> torch.Tensor:
     """Alias for :func:`fftconv2d_bhl_w_reshape_chunked`."""
     return fftconv2d_bhl_w_reshape_chunked(x, kernel, shortcut, chunk_size)
+
+
+# ===========================================================================
+# 1D causal long FFT conv — wraps subquadratic_ops_torch.fft_causal_conv1d
+# ===========================================================================
+
+_fft_causal_conv1d = None
+
+
+def _get_fft_causal_conv1d():
+    """Return the ``fft_causal_conv1d`` callable, importing on first call."""
+    global _fft_causal_conv1d
+    if _fft_causal_conv1d is None:
+        try:
+            from subquadratic_ops_torch.fft_causal_conv1d import fft_causal_conv1d
+
+            _fft_causal_conv1d = fft_causal_conv1d
+        except ImportError as exc:
+            raise ImportError(
+                "subquadratic_ops_torch is required for fft_backend='subq_ops'. "
+                "Install it with: pip install subquadratic_ops_torch"
+            ) from exc
+    return _fft_causal_conv1d
+
+
+def _subq_causal_conv1d_bhl(x_fp32: torch.Tensor, k_fp32: torch.Tensor) -> torch.Tensor:
+    """Call the subq_ops CUDA kernel on fp32 BHL tensors.
+
+    Upstream signature: weight ``[H, K]``. Handles both shared ``[1, H, K]`` (squeezed)
+    and 2D ``[H, K]`` (passed through).  Per-sample FiLM weights ``[B, H, K]`` are
+    *not* supported by the upstream kernel — callers must guard against that case.
+    """
+    fft_causal_conv1d = _get_fft_causal_conv1d()
+    if k_fp32.ndim == 3:
+        if k_fp32.shape[0] != 1:
+            raise NotImplementedError(
+                "subquadratic_ops_torch.fft_causal_conv1d does not accept per-sample "
+                f"FiLM weights. Got kernel shape {tuple(k_fp32.shape)} with batch={k_fp32.shape[0]}; "
+                "expected shared kernel [1, H, K] or [H, K]."
+            )
+        k = k_fp32.squeeze(0)
+    else:
+        k = k_fp32
+    return fft_causal_conv1d(x_fp32.contiguous(), k.contiguous())
+
+
+def causal_fftconv1d_bhl(
+    x: torch.Tensor,
+    kernel: torch.Tensor,
+    shortcut: torch.Tensor | None = None,
+) -> torch.Tensor:
+    """1D causal FFT convolution via subq_ops CUDA kernel, BHL layout ``[B, H, L]``.
+
+    Drop-in replacement for :func:`nvsubquadratic.ops.fftconv.causal_fftconv1d_fp32_bhl`.
+    Accepts any input dtype; internally casts to fp32 for the CUDA kernel and
+    returns the output in the original dtype of ``x``.
+
+    Args:
+        x: Input tensor ``[B, H, L]``.
+        kernel: Kernel tensor ``[1, H, K]`` or ``[H, K]``.  Per-sample FiLM weights
+            are not supported.
+        shortcut: Optional per-channel scale ``[H]``.
+
+    Returns:
+        Output tensor ``[B, H, L]`` in ``x.dtype``.
+    """
+    input_dtype = x.dtype
+    _B, H, _L = x.shape
+
+    y = _subq_causal_conv1d_bhl(x.float(), kernel.float()).to(input_dtype)
+
+    if shortcut is not None:
+        y = y + shortcut.to(input_dtype).view(1, H, 1) * x
+
+    return y
+
+
+def causal_fftconv1d_bhl_w_reshape(
+    x: torch.Tensor,
+    kernel: torch.Tensor,
+    shortcut: torch.Tensor | None = None,
+) -> torch.Tensor:
+    """1D causal FFT convolution via subq_ops for BLH inputs ``[B, L, H]``.
+
+    Reshapes to BHL, runs :func:`causal_fftconv1d_bhl`, reshapes back.
+    """
+    x_bhl = rearrange(x, "b l h -> b h l")
+    kernel_bhl = rearrange(kernel, "b l h -> b h l")
+    y_bhl = causal_fftconv1d_bhl(x_bhl, kernel_bhl, shortcut)
+    return rearrange(y_bhl, "b h l -> b l h")
+
+
+def causal_fftconv1d_blh(
+    x: torch.Tensor,
+    kernel: torch.Tensor,
+    shortcut: torch.Tensor | None = None,
+) -> torch.Tensor:
+    """Alias for :func:`causal_fftconv1d_bhl_w_reshape`."""
+    return causal_fftconv1d_bhl_w_reshape(x, kernel, shortcut)
+
+
+def causal_fftconv1d_bhl_chunked(
+    x: torch.Tensor,
+    kernel: torch.Tensor,
+    shortcut: torch.Tensor | None = None,
+    chunk_size: int | None = None,
+) -> torch.Tensor:
+    """Channel-chunked 1D causal FFT convolution via subq_ops, BHL layout."""
+    if chunk_size is None:
+        chunk_size = _DEFAULT_CHUNK_SIZE
+
+    input_dtype = x.dtype
+    _B, H, _L = x.shape
+    x_fp32 = x.float()
+    k_fp32 = kernel.float()
+
+    chunks = []
+    for start in range(0, H, chunk_size):
+        end = min(start + chunk_size, H)
+        x_c = x_fp32[:, start:end].contiguous()
+        k_c = k_fp32[:, start:end].contiguous()
+        chunks.append(_subq_causal_conv1d_bhl(x_c, k_c))
+
+    y = torch.cat(chunks, dim=1).to(input_dtype)
+
+    if shortcut is not None:
+        y = y + shortcut.to(input_dtype).view(1, H, 1) * x
+
+    return y
+
+
+def causal_fftconv1d_bhl_w_reshape_chunked(
+    x: torch.Tensor,
+    kernel: torch.Tensor,
+    shortcut: torch.Tensor | None = None,
+    chunk_size: int | None = None,
+) -> torch.Tensor:
+    """Channel-chunked 1D causal FFT convolution via subq_ops for BLH inputs."""
+    x_bhl = rearrange(x, "b l h -> b h l")
+    kernel_bhl = rearrange(kernel, "b l h -> b h l")
+    y_bhl = causal_fftconv1d_bhl_chunked(x_bhl, kernel_bhl, shortcut, chunk_size)
+    return rearrange(y_bhl, "b h l -> b l h")
+
+
+def causal_fftconv1d_blh_chunked(
+    x: torch.Tensor,
+    kernel: torch.Tensor,
+    shortcut: torch.Tensor | None = None,
+    chunk_size: int | None = None,
+) -> torch.Tensor:
+    """Alias for :func:`causal_fftconv1d_bhl_w_reshape_chunked`."""
+    return causal_fftconv1d_bhl_w_reshape_chunked(x, kernel, shortcut, chunk_size)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
     "rich>=13.0.0",
     "Pillow",
     "huggingface_hub",
-    "subquadratic-ops-torch-cu12",
+    "subquadratic-ops-torch-cu12>=0.2.0",
     "timm==1.0.24",
     "nvidia-dali-cuda120==1.53.0",
 ]

--- a/tests/modules/test_ckconv_nd_subq.py
+++ b/tests/modules/test_ckconv_nd_subq.py
@@ -203,9 +203,9 @@ class TestChunked:
 class TestAssertions:
     """CKConvND raises AssertionError for invalid subq_ops configurations."""
 
-    def test_rejects_data_dim_1(self):
-        """data_dim=1 is rejected."""
-        with pytest.raises(AssertionError, match="only supports 2D"):
+    def test_rejects_data_dim_1_non_causal(self):
+        """1D requires is_causal=True under subq_ops (no non-causal 1D kernel)."""
+        with pytest.raises(AssertionError, match="1D requires is_causal=True"):
             CKConvND(
                 data_dim=1,
                 hidden_dim=32,
@@ -218,7 +218,7 @@ class TestAssertions:
 
     def test_rejects_data_dim_3(self):
         """data_dim=3 is rejected."""
-        with pytest.raises(AssertionError, match="only supports 2D"):
+        with pytest.raises(AssertionError, match=r"only supports data_dim in \(1, 2\)"):
             CKConvND(
                 data_dim=3,
                 hidden_dim=32,
@@ -230,7 +230,7 @@ class TestAssertions:
             )
 
     def test_rejects_circular_padding(self):
-        """fft_padding='circular' is rejected."""
+        """fft_padding='circular' is rejected on the 2D path."""
         with pytest.raises(AssertionError, match="only supports zero-padded"):
             CKConvND(
                 data_dim=2,
@@ -247,20 +247,6 @@ class TestAssertions:
         with pytest.raises(AssertionError, match="Causal CKConvND only supports 1D"):
             CKConvND(
                 data_dim=2,
-                hidden_dim=32,
-                kernel_cfg=LazyConfig(torch.nn.Identity)(),
-                mask_cfg=LazyConfig(torch.nn.Identity)(),
-                grid_type="double",
-                fft_padding="zero",
-                is_causal=True,
-                fft_backend="subq_ops",
-            )
-
-    def test_rejects_causal_with_1d(self):
-        """is_causal=True + data_dim=1 hits the subq_ops data_dim=2 constraint."""
-        with pytest.raises(AssertionError, match="only supports 2D"):
-            CKConvND(
-                data_dim=1,
                 hidden_dim=32,
                 kernel_cfg=LazyConfig(torch.nn.Identity)(),
                 mask_cfg=LazyConfig(torch.nn.Identity)(),
@@ -296,3 +282,83 @@ class TestAssertions:
                 fft_padding="zero",
                 fft_backend="invalid",
             )
+
+
+# ---------------------------------------------------------------------------
+# 1D causal integration — subq_ops vs torch_fft parity
+# ---------------------------------------------------------------------------
+
+
+HIDDEN_DIM_1D = 32
+SEQ_LEN_1D = 128
+
+
+def _make_ckconv_1d(fft_backend, use_chunked=False):
+    """Build a 1D causal CKConvND with a small SIREN kernel."""
+    kernel_cfg = LazyConfig(SIRENKernelND)(
+        data_dim=1,
+        out_dim=HIDDEN_DIM_1D,
+        mlp_hidden_dim=16,
+        num_layers=2,
+        embedding_dim=16,
+        omega_0=100.0,
+        L_cache=SEQ_LEN_1D,
+        use_bias=True,
+    )
+    return CKConvND(
+        data_dim=1,
+        hidden_dim=HIDDEN_DIM_1D,
+        kernel_cfg=kernel_cfg,
+        mask_cfg=LazyConfig(torch.nn.Identity)(),
+        grid_type="double",
+        fft_padding="zero",
+        is_causal=True,
+        fft_backend=fft_backend,
+        use_chunked_fftconv=use_chunked,
+    )
+
+
+class Test1DCausalForwardBackward:
+    """CKConvND 1D causal with subq_ops matches the torch_fft reference."""
+
+    def test_forward_matches(self):
+        torch.manual_seed(42)
+        model_ref = _make_ckconv_1d("torch_fft").cuda()
+        model_subq = _make_ckconv_1d("subq_ops").cuda()
+        _sync_weights(model_ref, model_subq)
+
+        x = torch.randn(2, SEQ_LEN_1D, HIDDEN_DIM_1D, device="cuda", dtype=torch.float32)
+        torch.testing.assert_close(model_subq(x), model_ref(x), atol=ATOL, rtol=RTOL)
+
+    def test_backward_matches(self):
+        torch.manual_seed(42)
+        model_ref = _make_ckconv_1d("torch_fft").cuda()
+        model_subq = _make_ckconv_1d("subq_ops").cuda()
+        _sync_weights(model_ref, model_subq)
+
+        x_ref = torch.randn(2, SEQ_LEN_1D, HIDDEN_DIM_1D, device="cuda", dtype=torch.float32, requires_grad=True)
+        x_sub = x_ref.detach().clone().requires_grad_(True)
+        model_ref(x_ref).sum().backward()
+        model_subq(x_sub).sum().backward()
+
+        torch.testing.assert_close(x_sub.grad, x_ref.grad, atol=ATOL_GRAD, rtol=RTOL_GRAD)
+
+        ref_grads = {n: p.grad for n, p in model_ref.named_parameters() if p.grad is not None}
+        subq_grads = {n: p.grad for n, p in model_subq.named_parameters() if p.grad is not None}
+        for name in ref_grads:
+            torch.testing.assert_close(
+                subq_grads[name],
+                ref_grads[name],
+                atol=ATOL_GRAD,
+                rtol=RTOL_GRAD,
+                msg=f"Gradient mismatch for {name}",
+            )
+
+    def test_chunked_matches_non_chunked(self):
+        torch.manual_seed(42)
+        model = _make_ckconv_1d("subq_ops", use_chunked=False).cuda()
+        model_chunk = _make_ckconv_1d("subq_ops", use_chunked=True).cuda()
+        _sync_weights(model, model_chunk)
+
+        x = torch.randn(2, SEQ_LEN_1D, HIDDEN_DIM_1D, device="cuda", dtype=torch.float32)
+        torch.testing.assert_close(model_chunk(x), model(x), atol=0, rtol=0)

--- a/tests/modules/test_ckconv_nd_subq.py
+++ b/tests/modules/test_ckconv_nd_subq.py
@@ -362,3 +362,18 @@ class Test1DCausalForwardBackward:
 
         x = torch.randn(2, SEQ_LEN_1D, HIDDEN_DIM_1D, device="cuda", dtype=torch.float32)
         torch.testing.assert_close(model_chunk(x), model(x), atol=0, rtol=0)
+
+    def test_forward_bhl_input(self):
+        """is_bhl_input=True path (BHL layout) matches torch_fft reference."""
+        torch.manual_seed(42)
+        model_ref = _make_ckconv_1d("torch_fft").cuda()
+        model_subq = _make_ckconv_1d("subq_ops").cuda()
+        _sync_weights(model_ref, model_subq)
+
+        x = torch.randn(2, HIDDEN_DIM_1D, SEQ_LEN_1D, device="cuda", dtype=torch.float32)
+        torch.testing.assert_close(
+            model_subq(x, is_bhl_input=True),
+            model_ref(x, is_bhl_input=True),
+            atol=ATOL,
+            rtol=RTOL,
+        )

--- a/tests/modules/test_subq_ops_causal_conv1d.py
+++ b/tests/modules/test_subq_ops_causal_conv1d.py
@@ -1,0 +1,135 @@
+# TODO: Add license header here
+
+
+"""Tests for SubqOpsCausalConv1d module.
+
+Validates :class:`nvsubquadratic.modules.subq_ops_causal_conv1d.SubqOpsCausalConv1d`
+against the existing :class:`nvsubquadratic.modules.causal_conv1d.CausalConv1D`
+torch reference.
+
+Covers:
+  - Forward correctness (no bias and with bias)
+  - Backward gradient correctness
+  - SiLU activation path
+  - Construction-time constraint asserts (depthwise-only, valid activation)
+  - State-dict round-trip with the torch reference (shared parameter layout)
+
+Usage (requires GPU):
+    srun --gres=gpu:1 -c 16 --partition low \\
+        conda run -n nv-subq python -m pytest tests/modules/test_subq_ops_causal_conv1d.py -v -o addopts=""
+"""
+
+import pytest
+import torch
+import torch.nn.functional as F
+
+from nvsubquadratic.modules.causal_conv1d import CausalConv1D
+
+
+ATOL = 1e-3
+RTOL = 1e-4
+ATOL_GRAD = 1e-2
+RTOL_GRAD = 1e-3
+
+
+def _has_subq_ops() -> bool:
+    try:
+        from subquadratic_ops_torch.causal_conv1d import causal_conv1d  # noqa: F401
+
+        return True
+    except ImportError:
+        return False
+
+
+requires_subq_ops = pytest.mark.skipif(
+    not _has_subq_ops(),
+    reason="subquadratic_ops_torch.causal_conv1d not available",
+)
+requires_cuda = pytest.mark.skipif(
+    not torch.cuda.is_available(),
+    reason="CUDA not available",
+)
+
+pytestmark = [requires_subq_ops, requires_cuda]
+
+
+def _import_module():
+    from nvsubquadratic.modules.subq_ops_causal_conv1d import SubqOpsCausalConv1d
+
+    return SubqOpsCausalConv1d
+
+
+class TestForward:
+    @pytest.mark.parametrize("C, L, K", [(36, 256, 3), (64, 512, 7), (16, 128, 4)])
+    def test_matches_causal_conv1d(self, C, L, K):
+        SubqOpsCausalConv1d = _import_module()
+        torch.manual_seed(42)
+        ref = CausalConv1D(C, C, K, groups=C, bias=False).cuda()
+        fast = SubqOpsCausalConv1d(C, C, K, groups=C, bias=False).cuda()
+        fast.load_state_dict(ref.state_dict())
+
+        x = torch.randn(2, C, L, device="cuda", dtype=torch.float32)
+        torch.testing.assert_close(fast(x), ref(x), atol=ATOL, rtol=RTOL)
+
+    def test_with_bias(self):
+        SubqOpsCausalConv1d = _import_module()
+        torch.manual_seed(42)
+        C, L, K = 36, 256, 3
+        ref = CausalConv1D(C, C, K, groups=C, bias=True).cuda()
+        fast = SubqOpsCausalConv1d(C, C, K, groups=C, bias=True).cuda()
+        fast.load_state_dict(ref.state_dict())
+        x = torch.randn(2, C, L, device="cuda", dtype=torch.float32)
+        torch.testing.assert_close(fast(x), ref(x), atol=ATOL, rtol=RTOL)
+
+    def test_silu_activation(self):
+        """activation='silu' applies SiLU after the conv."""
+        SubqOpsCausalConv1d = _import_module()
+        torch.manual_seed(42)
+        C, L, K = 36, 256, 3
+        ref = CausalConv1D(C, C, K, groups=C, bias=False).cuda()
+        fast = SubqOpsCausalConv1d(C, C, K, groups=C, bias=False, activation="silu").cuda()
+        fast.load_state_dict(ref.state_dict())
+        x = torch.randn(2, C, L, device="cuda", dtype=torch.float32)
+        torch.testing.assert_close(fast(x), F.silu(ref(x)), atol=ATOL, rtol=RTOL)
+
+
+class TestBackward:
+    def test_grad_matches_causal_conv1d(self):
+        SubqOpsCausalConv1d = _import_module()
+        torch.manual_seed(42)
+        C, L, K = 36, 256, 3
+        ref = CausalConv1D(C, C, K, groups=C, bias=True).cuda()
+        fast = SubqOpsCausalConv1d(C, C, K, groups=C, bias=True).cuda()
+        fast.load_state_dict(ref.state_dict())
+
+        x_ref = torch.randn(2, C, L, device="cuda", dtype=torch.float32, requires_grad=True)
+        x_fast = x_ref.detach().clone().requires_grad_(True)
+        ref(x_ref).sum().backward()
+        fast(x_fast).sum().backward()
+
+        torch.testing.assert_close(x_fast.grad, x_ref.grad, atol=ATOL_GRAD, rtol=RTOL_GRAD)
+        torch.testing.assert_close(fast.weight.grad, ref.weight.grad, atol=ATOL_GRAD, rtol=RTOL_GRAD)
+        torch.testing.assert_close(fast.bias.grad, ref.bias.grad, atol=ATOL_GRAD, rtol=RTOL_GRAD)
+
+
+class TestConstruction:
+    def test_rejects_non_depthwise(self):
+        SubqOpsCausalConv1d = _import_module()
+        with pytest.raises(ValueError, match="depthwise-only"):
+            SubqOpsCausalConv1d(in_channels=16, out_channels=16, kernel_size=3, groups=4)
+
+    def test_rejects_in_neq_out(self):
+        SubqOpsCausalConv1d = _import_module()
+        with pytest.raises(ValueError, match="depthwise-only"):
+            SubqOpsCausalConv1d(in_channels=16, out_channels=32, kernel_size=3, groups=16)
+
+    def test_rejects_invalid_activation(self):
+        SubqOpsCausalConv1d = _import_module()
+        with pytest.raises(ValueError, match="activation"):
+            SubqOpsCausalConv1d(in_channels=16, out_channels=16, kernel_size=3, groups=16, activation="relu")
+
+    def test_is_nn_conv1d_subclass(self):
+        """Hyena's isinstance(short_conv, nn.Conv1d) check must pass."""
+        SubqOpsCausalConv1d = _import_module()
+        m = SubqOpsCausalConv1d(in_channels=16, out_channels=16, kernel_size=3, groups=16)
+        assert isinstance(m, torch.nn.Conv1d)

--- a/tests/ops/test_causal_conv1d_custom.py
+++ b/tests/ops/test_causal_conv1d_custom.py
@@ -1,0 +1,121 @@
+# TODO: Add license header here
+
+
+"""Tests for the direct (non-FFT) 1D causal conv wrappers.
+
+Validates :mod:`nvsubquadratic.ops.causal_conv1d_custom`:
+
+- :func:`causal_conv1d` — depthwise short causal conv (also exercised
+  indirectly via :class:`SubqOpsCausalConv1d`, but tested here standalone for
+  silu and bias paths).
+- :func:`b2b_causal_conv1d` — fused back-to-back causal conv. Not wired into
+  any module yet; this test pins the output shape contract so a future
+  fused-Hyena variant can rely on it.
+
+Usage (requires GPU):
+    srun --gres=gpu:1 -c 16 --partition low \\
+        conda run -n nv-subq python -m pytest tests/ops/test_causal_conv1d_custom.py -v -o addopts=""
+"""
+
+import pytest
+import torch
+import torch.nn.functional as F
+
+
+ATOL = 1e-3
+RTOL = 1e-4
+
+
+def _has_subq_ops() -> bool:
+    try:
+        from subquadratic_ops_torch.b2b_causal_conv1d import b2b_causal_conv1d  # noqa: F401
+        from subquadratic_ops_torch.causal_conv1d import causal_conv1d  # noqa: F401
+
+        return True
+    except ImportError:
+        return False
+
+
+requires_subq_ops = pytest.mark.skipif(
+    not _has_subq_ops(),
+    reason="subquadratic_ops_torch direct 1D kernels not available",
+)
+requires_cuda = pytest.mark.skipif(
+    not torch.cuda.is_available(),
+    reason="CUDA not available",
+)
+
+pytestmark = [requires_subq_ops, requires_cuda]
+
+
+class TestCausalConv1d:
+    """Direct tests for nvsubquadratic.ops.causal_conv1d_custom.causal_conv1d."""
+
+    def _torch_ref(self, x, weight, bias, activation):
+        """Reference: causal pad + F.conv1d + activation."""
+        K = weight.shape[-1]
+        x_padded = F.pad(x, (K - 1, 0))
+        w_3d = weight.unsqueeze(1)  # [C, K] -> [C, 1, K] for nn.Conv1d depthwise
+        y = F.conv1d(x_padded, w_3d, bias, groups=weight.shape[0])
+        return F.silu(y) if activation == "silu" else y
+
+    @pytest.mark.parametrize("C, L, K", [(16, 64, 3), (36, 256, 3), (64, 128, 7)])
+    def test_matches_reference_no_bias(self, C, L, K):
+        from nvsubquadratic.ops.causal_conv1d_custom import causal_conv1d
+
+        torch.manual_seed(42)
+        x = torch.randn(2, C, L, device="cuda", dtype=torch.float32)
+        w = torch.randn(C, K, device="cuda", dtype=torch.float32)
+
+        y = causal_conv1d(x, w, None, "identity")
+        y_ref = self._torch_ref(x, w, None, "identity")
+        torch.testing.assert_close(y, y_ref, atol=ATOL, rtol=RTOL)
+
+    def test_matches_reference_with_bias(self):
+        from nvsubquadratic.ops.causal_conv1d_custom import causal_conv1d
+
+        torch.manual_seed(42)
+        C, L, K = 36, 256, 3
+        x = torch.randn(2, C, L, device="cuda", dtype=torch.float32)
+        w = torch.randn(C, K, device="cuda", dtype=torch.float32)
+        b = torch.randn(C, device="cuda", dtype=torch.float32)
+
+        y = causal_conv1d(x, w, b, "identity")
+        y_ref = self._torch_ref(x, w, b, "identity")
+        torch.testing.assert_close(y, y_ref, atol=ATOL, rtol=RTOL)
+
+    def test_silu_activation(self):
+        from nvsubquadratic.ops.causal_conv1d_custom import causal_conv1d
+
+        torch.manual_seed(42)
+        C, L, K = 36, 256, 3
+        x = torch.randn(2, C, L, device="cuda", dtype=torch.float32)
+        w = torch.randn(C, K, device="cuda", dtype=torch.float32)
+
+        y = causal_conv1d(x, w, None, "silu")
+        y_ref = self._torch_ref(x, w, None, "silu")
+        torch.testing.assert_close(y, y_ref, atol=ATOL, rtol=RTOL)
+
+
+class TestB2BCausalConv1d:
+    """Shape + finiteness contract for the b2b fused kernel.
+
+    This is the only test for b2b_causal_conv1d in the suite — the wrapper is
+    a thin pass-through and the kernel itself is upstream's responsibility.
+    A future fused-Hyena module will add semantic tests.
+    """
+
+    # b2b kernel supports specific projection kernel sizes only.
+    @pytest.mark.parametrize("B, C, L, K", [(2, 16, 64, 3), (4, 32, 128, 4), (2, 16, 128, 8)])
+    def test_output_shape_and_finite(self, B, C, L, K):
+        from nvsubquadratic.ops.causal_conv1d_custom import b2b_causal_conv1d
+
+        torch.manual_seed(42)
+        x = torch.randn(B, 3 * C, L, device="cuda", dtype=torch.float32)
+        w_proj = torch.randn(3 * C, K, device="cuda", dtype=torch.float32)
+        w_mixer = torch.randn(C, K, device="cuda", dtype=torch.float32)
+        skip_bias = torch.randn(C, device="cuda", dtype=torch.float32)
+
+        y = b2b_causal_conv1d(x, w_proj, w_mixer, skip_bias)
+        assert y.shape == (B, C, L)
+        assert torch.isfinite(y).all()

--- a/tests/ops/test_fftconv_custom_1d.py
+++ b/tests/ops/test_fftconv_custom_1d.py
@@ -200,6 +200,22 @@ class TestDtype:
         assert torch.isfinite(y).all()
 
 
+class TestLongKernel:
+    """Long kernels — where the FFT kernel beats the direct conv (upstream docstring: K>=128)."""
+
+    @pytest.mark.parametrize("K", [128, 512, 2048])
+    def test_long_kernel_matches_reference(self, device, K):
+        torch.manual_seed(42)
+        B, H, L = 1, 32, max(K, 256)
+        x = torch.randn(B, H, L, device=device, dtype=torch.float32)
+        k = torch.randn(1, H, K, device=device, dtype=torch.float32)
+
+        y_ref = _ref_bhl(x, k)
+        y_custom = _custom_bhl(x, k)
+
+        torch.testing.assert_close(y_custom, y_ref, atol=ATOL_F32, rtol=RTOL_F32)
+
+
 class TestErrors:
     """Negative cases."""
 

--- a/tests/ops/test_fftconv_custom_1d.py
+++ b/tests/ops/test_fftconv_custom_1d.py
@@ -1,0 +1,211 @@
+# TODO: Add license header here
+
+
+"""Tests for the 1D causal subq_ops wrappers in fftconv_custom.
+
+Validates :func:`nvsubquadratic.ops.fftconv_custom.causal_fftconv1d_*` against
+the torch.fft reference :func:`nvsubquadratic.ops.fftconv.causal_fftconv1d_fp32_bhl`.
+
+Covers:
+  - Forward correctness: shared kernel, BHL and BLH layouts
+  - Chunked vs non-chunked consistency
+  - Backward correctness: gradient comparison for x and kernel
+  - Shortcut semantics
+  - Dtype handling: bf16, fp16, fp32 inputs
+  - Negative case: per-sample FiLM weights raise NotImplementedError
+
+Usage (requires GPU — run inside SLURM):
+    srun --gres=gpu:1 -c 16 --partition low \\
+        conda run -n nv-subq python -m pytest tests/ops/test_fftconv_custom_1d.py -v -o addopts=""
+"""
+
+import pytest
+import torch
+
+
+ATOL_F32 = 1e-3
+RTOL_F32 = 1e-4
+ATOL_GRAD = 1e-2
+RTOL_GRAD = 1e-3
+
+
+def _has_subq_ops_1d() -> bool:
+    try:
+        from subquadratic_ops_torch.fft_causal_conv1d import fft_causal_conv1d  # noqa: F401
+
+        return True
+    except ImportError:
+        return False
+
+
+requires_subq_ops_1d = pytest.mark.skipif(
+    not _has_subq_ops_1d(),
+    reason="subquadratic_ops_torch.fft_causal_conv1d not available",
+)
+requires_cuda = pytest.mark.skipif(
+    not torch.cuda.is_available(),
+    reason="CUDA not available",
+)
+
+pytestmark = [requires_subq_ops_1d, requires_cuda]
+
+
+@pytest.fixture
+def device() -> str:
+    return "cuda"
+
+
+def _ref_bhl(x, kernel, shortcut=None):
+    from nvsubquadratic.ops.fftconv import causal_fftconv1d_fp32_bhl
+
+    return causal_fftconv1d_fp32_bhl(x, kernel, shortcut)
+
+
+def _ref_blh(x, kernel, shortcut=None):
+    from nvsubquadratic.ops.fftconv import causal_fftconv1d_fp32_bhl_w_reshape
+
+    return causal_fftconv1d_fp32_bhl_w_reshape(x, kernel, shortcut)
+
+
+def _custom_bhl(x, kernel, shortcut=None):
+    from nvsubquadratic.ops.fftconv_custom import causal_fftconv1d_bhl
+
+    return causal_fftconv1d_bhl(x, kernel, shortcut)
+
+
+def _custom_blh(x, kernel, shortcut=None):
+    from nvsubquadratic.ops.fftconv_custom import causal_fftconv1d_bhl_w_reshape
+
+    return causal_fftconv1d_bhl_w_reshape(x, kernel, shortcut)
+
+
+def _custom_bhl_chunked(x, kernel, shortcut=None, chunk_size=None):
+    from nvsubquadratic.ops.fftconv_custom import causal_fftconv1d_bhl_chunked
+
+    return causal_fftconv1d_bhl_chunked(x, kernel, shortcut, chunk_size)
+
+
+def _custom_blh_chunked(x, kernel, shortcut=None, chunk_size=None):
+    from nvsubquadratic.ops.fftconv_custom import causal_fftconv1d_bhl_w_reshape_chunked
+
+    return causal_fftconv1d_bhl_w_reshape_chunked(x, kernel, shortcut, chunk_size)
+
+
+SHARED_SHAPES = [
+    # (B, H, L, K)
+    (2, 64, 256, 7),
+    (4, 128, 512, 7),
+    (1, 256, 1024, 15),
+    (2, 32, 128, 3),
+    (1, 96, 2048, 65),
+    (2, 64, 64, 64),  # K == L edge case
+]
+
+
+class TestForward:
+    """Forward correctness vs torch.fft reference."""
+
+    @pytest.mark.parametrize("B, H, L, K", SHARED_SHAPES)
+    def test_bhl_shared_kernel(self, device, B, H, L, K):
+        torch.manual_seed(42)
+        x = torch.randn(B, H, L, device=device, dtype=torch.float32)
+        k = torch.randn(1, H, K, device=device, dtype=torch.float32)
+
+        y_ref = _ref_bhl(x, k)
+        y_custom = _custom_bhl(x, k)
+
+        torch.testing.assert_close(y_custom, y_ref, atol=ATOL_F32, rtol=RTOL_F32)
+
+    @pytest.mark.parametrize("B, H, L, K", SHARED_SHAPES)
+    def test_blh_shared_kernel(self, device, B, H, L, K):
+        torch.manual_seed(42)
+        x = torch.randn(B, L, H, device=device, dtype=torch.float32)
+        k = torch.randn(1, K, H, device=device, dtype=torch.float32)
+
+        y_ref = _ref_blh(x, k)
+        y_custom = _custom_blh(x, k)
+
+        torch.testing.assert_close(y_custom, y_ref, atol=ATOL_F32, rtol=RTOL_F32)
+
+    @pytest.mark.parametrize("B, H, L, K", SHARED_SHAPES[:3])
+    def test_shortcut_semantics(self, device, B, H, L, K):
+        torch.manual_seed(42)
+        x = torch.randn(B, H, L, device=device, dtype=torch.float32)
+        k = torch.randn(1, H, K, device=device, dtype=torch.float32)
+        shortcut = torch.randn(H, device=device, dtype=torch.float32)
+
+        y_ref = _ref_bhl(x, k, shortcut)
+        y_custom = _custom_bhl(x, k, shortcut)
+
+        torch.testing.assert_close(y_custom, y_ref, atol=ATOL_F32, rtol=RTOL_F32)
+
+
+class TestChunked:
+    """Chunked variant matches non-chunked output."""
+
+    @pytest.mark.parametrize("B, H, L, K", SHARED_SHAPES[:4])
+    @pytest.mark.parametrize("chunk_size", [16, 32, 128])
+    def test_bhl_chunked_matches(self, device, B, H, L, K, chunk_size):
+        torch.manual_seed(42)
+        x = torch.randn(B, H, L, device=device, dtype=torch.float32)
+        k = torch.randn(1, H, K, device=device, dtype=torch.float32)
+        shortcut = torch.randn(H, device=device, dtype=torch.float32)
+
+        y_unchunked = _custom_bhl(x, k, shortcut)
+        y_chunked = _custom_bhl_chunked(x, k, shortcut, chunk_size)
+
+        torch.testing.assert_close(y_chunked, y_unchunked, atol=ATOL_F32, rtol=RTOL_F32)
+
+    def test_blh_chunked_matches(self, device):
+        torch.manual_seed(42)
+        B, H, L, K = 2, 64, 256, 7
+        x = torch.randn(B, L, H, device=device, dtype=torch.float32)
+        k = torch.randn(1, K, H, device=device, dtype=torch.float32)
+
+        y_unchunked = _custom_blh(x, k)
+        y_chunked = _custom_blh_chunked(x, k, chunk_size=32)
+
+        torch.testing.assert_close(y_chunked, y_unchunked, atol=ATOL_F32, rtol=RTOL_F32)
+
+
+class TestBackward:
+    """Gradient correctness vs torch.fft reference."""
+
+    @pytest.mark.parametrize("B, H, L, K", [(2, 64, 256, 7), (4, 32, 128, 5)])
+    def test_grad_matches_reference(self, device, B, H, L, K):
+        torch.manual_seed(42)
+        x_ref = torch.randn(B, H, L, device=device, dtype=torch.float32, requires_grad=True)
+        k_ref = torch.randn(1, H, K, device=device, dtype=torch.float32, requires_grad=True)
+        y_ref = _ref_bhl(x_ref, k_ref)
+        y_ref.sum().backward()
+
+        x_s = x_ref.detach().clone().requires_grad_(True)
+        k_s = k_ref.detach().clone().requires_grad_(True)
+        y_s = _custom_bhl(x_s, k_s)
+        y_s.sum().backward()
+
+        torch.testing.assert_close(x_s.grad, x_ref.grad, atol=ATOL_GRAD, rtol=RTOL_GRAD)
+        torch.testing.assert_close(k_s.grad, k_ref.grad, atol=ATOL_GRAD, rtol=RTOL_GRAD)
+
+
+class TestDtype:
+    """Input dtype is preserved on output; non-fp32 inputs are upcast internally."""
+
+    @pytest.mark.parametrize("in_dtype", [torch.bfloat16, torch.float16, torch.float32])
+    def test_dtype_preserved(self, device, in_dtype):
+        x = torch.randn(2, 32, 128, device=device, dtype=in_dtype)
+        k = torch.randn(1, 32, 5, device=device, dtype=in_dtype)
+        y = _custom_bhl(x, k)
+        assert y.dtype == in_dtype
+        assert torch.isfinite(y).all()
+
+
+class TestErrors:
+    """Negative cases."""
+
+    def test_per_sample_film_weights_rejected(self, device):
+        """The upstream 1D kernel does not accept batched weights."""
+        x = torch.randn(2, 32, 128, device=device, dtype=torch.float32)
+        k = torch.randn(2, 32, 5, device=device, dtype=torch.float32)  # B=2 not B=1
+        with pytest.raises(NotImplementedError, match="per-sample FiLM weights"):
+            _custom_bhl(x, k)


### PR DESCRIPTION
## Summary

Wires the 1D CUDA kernels from `subquadratic-ops-torch-cu12` into nvSubquadratic. Before this PR, `fft_backend="subq_ops"` only accepted 2D non-causal configs; the upstream package's 1D kernels (`fft_causal_conv1d`, `causal_conv1d`, `b2b_causal_conv1d`) were not exposed.

## What lands

**Long FFT conv (`fft_causal_conv1d`)** — wired into `CKConvND` via `fft_backend="subq_ops"` for `data_dim=1, is_causal=True`. Drop-in replacement for the `torch.fft` reference; the kernel beats the direct conv at K ≥ 128 (upstream guidance). Supports chunked and non-chunked, BHL and BLH input layouts. Shared kernel only — the upstream 1D kernel does not accept batched (per-sample / FiLM) weights, so the wrapper raises `NotImplementedError` for `B>1` kernels.

**Short causal conv (`causal_conv1d`)** — exposed as `SubqOpsCausalConv1d`, an `nn.Conv1d` subclass restricted to depthwise (`groups == in_channels == out_channels`). Drop-in for Hyena's `short_conv` slot when the host is 1D autoregressive. Supports `activation="silu"` (fused) and the standard identity path.

**b2b fused kernel (`b2b_causal_conv1d`)** — exposed as a thin pass-through function in `nvsubquadratic.ops.causal_conv1d_custom`. **Not yet wired into any module.** Designed to be the building block for a future `FusedHyena1D` variant; this PR only stabilizes the import surface.

## Capability matrix after this PR

| `fft_backend` | `data_dim` | `is_causal` | Status |
|---|---|---|---|
| `subq_ops` | 2 | False | Existed |
| `subq_ops` | 1 | True | **New** |
| `subq_ops` | 1 | False | Rejected at construction (no 1D non-causal kernel upstream) |
| `subq_ops` | 3 | * | Rejected at construction |
| `torch_fft` | * | * | Unchanged |


## Notes
- `b2b_causal_conv1d` is exposed but not module-integrated. A `FusedHyena1D` module (which would bypass `Hyena.forward` and call the fused kernel directly) is a follow-up; benchmarking the fused vs. unfused path is its own piece of work.
- No new examples / configs. Adding a striped 1D causal LM config that uses `fft_backend="subq_ops"` end-to-end is out of scope here; the smoke test in `Test1DCausalForwardBackward` is enough to verify the wiring.


## Environment setup

Create the conda environment (required to run tests):

```bash
bash setup_conda_env.sh
conda activate nvsubquadratic
```

## Pre-commit

Run locally before pushing:

```bash
pre-commit install
pre-commit run --all-files
```

## Test plan

<!-- How did you test this? Bulleted checklist preferred. -->
