### PR TITLE
Sphinx docs setup

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,50 @@
+name: Build & Deploy Docs
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "docs/**"
+      - "nvsubquadratic/**"
+      - "pyproject.toml"
+      - ".github/workflows/docs.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install docs dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r docs/requirements.txt
+
+      - name: Install package (for autodoc imports)
+        run: pip install -e . --no-deps
+
+      - name: Build HTML
+        run: make -C docs html SPHINXBUILD="python -m sphinx"
+
+      - name: Deploy to gh-pages
+        if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./docs/_build/html
+          publish_branch: gh-pages
+          force_orphan: true

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -40,6 +40,9 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r docs/requirements.txt
 
+      - name: Install CPU torch (autodoc needs it at import time)
+        run: pip install torch --index-url https://download.pytorch.org/whl/cpu
+
       - name: Install package (for autodoc imports)
         run: pip install -e . --no-deps
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -8,6 +8,12 @@ on:
       - "nvsubquadratic/**"
       - "pyproject.toml"
       - ".github/workflows/docs.yml"
+  pull_request:
+    paths:
+      - "docs/**"
+      - "nvsubquadratic/**"
+      - "pyproject.toml"
+      - ".github/workflows/docs.yml"
   workflow_dispatch:
 
 permissions:
@@ -41,7 +47,7 @@ jobs:
         run: make -C docs html SPHINXBUILD="python -m sphinx"
 
       - name: Deploy to gh-pages
-        if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
+        if: (github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event_name == 'workflow_dispatch'
         uses: peaceiris/actions-gh-pages@v4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -47,7 +47,7 @@ jobs:
         run: pip install -e . --no-deps
 
       - name: Build HTML
-        run: make -C docs html SPHINXBUILD="python -m sphinx"
+        run: make -C docs html SPHINXBUILD="python -m sphinx" SPHINXOPTS="-W --keep-going"
 
       - name: Deploy to gh-pages
         if: (github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event_name == 'workflow_dispatch'

--- a/.gitignore
+++ b/.gitignore
@@ -72,6 +72,7 @@ instance/
 
 # Sphinx documentation
 docs/_build/
+docs/generated/
 
 # PyBuilder
 .pybuilder/

--- a/README.md
+++ b/README.md
@@ -153,6 +153,21 @@ PYTHONPATH=. python -m pytest tests/ -m "not nightly" -v -o addopts=""
 source .env && PYTHONPATH=. python -m pytest tests/ -m nightly -v -o addopts=""
 ```
 
+### Documentation
+
+The API reference is built with Sphinx. Sources live under [`docs/`](docs/) and the rendered site is published to the `gh-pages` branch on every push to `main` via [`.github/workflows/docs.yml`](.github/workflows/docs.yml).
+
+Build and preview locally:
+
+```bash
+pip install -r docs/requirements.txt
+pip install -e . --no-deps
+make -C docs html SPHINXBUILD="python -m sphinx"
+python -m http.server 8000 --directory docs/_build/html
+```
+
+Open <http://localhost:8000> to browse. The autosummary stubs in `docs/generated/` are regenerated on every build (gitignored).
+
 ### CI
 
 GPU tests run automatically on pull requests via a self-hosted [Colossus](https://colossus.nvidia.com) runner.

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,0 +1,20 @@
+# Minimal makefile for Sphinx documentation
+#
+
+# You can set these variables from the command line, and also
+# from the environment for the first two.
+SPHINXOPTS    ?=
+SPHINXBUILD   ?= sphinx-build
+SOURCEDIR     = .
+BUILDDIR      = _build
+
+# Put it first so that "make" without argument is like "make help".
+help:
+	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+.PHONY: help Makefile
+
+# Catch-all target: route all unknown targets to Sphinx using the new
+# "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
+%: Makefile
+	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/docs/_static/custom.css
+++ b/docs/_static/custom.css
@@ -1,0 +1,7 @@
+/* Custom CSS overrides for nvidia_sphinx_theme. */
+
+/* Add a touch more space around math blocks so LaTeX in docstrings reads cleanly. */
+div.math {
+    margin-top: 0.6em;
+    margin-bottom: 0.6em;
+}

--- a/docs/_templates/class_template.rst
+++ b/docs/_templates/class_template.rst
@@ -1,0 +1,9 @@
+.. SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+{{ objname | escape | underline }}
+
+.. currentmodule:: {{ module }}
+
+.. autoclass:: {{ objname }}
+   :members:
+   :show-inheritance:

--- a/docs/_templates/function_template.rst
+++ b/docs/_templates/function_template.rst
@@ -1,0 +1,7 @@
+.. SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+{{ objname | escape | underline}}
+
+.. currentmodule:: {{ module }}
+
+.. autofunction:: {{ objname }}

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -1,0 +1,109 @@
+.. SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+.. module:: nvsubquadratic
+.. currentmodule:: nvsubquadratic
+
+API Reference
+=============
+
+The reference is organised bottom-up: low-level FFT convolution primitives
+first, then the mixer modules that compose them. See [`docs/ops/README.md`](ops/README.md)
+for the math motivation behind the FFT-based ops, and
+``docs-tracker.md`` at the repo root for the documentation coverage plan.
+
+Ops — FFT convolutions (reference fp32)
+---------------------------------------
+
+Reference implementations in pure PyTorch FFT. Use these for correctness
+and as the spec the CUDA kernels must match.
+
+.. autosummary::
+   :toctree: generated/
+   :template: function_template.rst
+
+   ~ops.fftconv.fftconv1d_fp32_blh
+   ~ops.fftconv.fftconv2d_fp32_blh
+   ~ops.fftconv.fftconv3d_fp32_blh
+   ~ops.fftconv.causal_fftconv1d_fp32_blh
+   ~ops.fftconv.fftconv1d_fp32_bhl
+   ~ops.fftconv.fftconv2d_fp32_bhl
+   ~ops.fftconv.fftconv3d_fp32_bhl
+   ~ops.fftconv.causal_fftconv1d_fp32_bhl
+
+Ops — FFT convolutions (CUDA-accelerated)
+-----------------------------------------
+
+Drop-in wrappers around the ``subquadratic_ops_torch`` fused CUDA kernels.
+
+.. autosummary::
+   :toctree: generated/
+   :template: function_template.rst
+
+   ~ops.fftconv_custom.fftconv2d_blh
+   ~ops.fftconv_custom.fftconv2d_bhl
+   ~ops.fftconv_custom.fftconv2d_bhl_w_reshape
+
+Ops — Circular FFT convolutions
+-------------------------------
+
+Periodic-boundary FFT convolutions for global mixing without zero padding.
+
+.. autosummary::
+   :toctree: generated/
+   :template: function_template.rst
+
+   ~ops.circular_fftconv.circular_fftconv1d_fp32_bhl
+   ~ops.circular_fftconv.circular_fftconv2d_fp32_bhl
+   ~ops.circular_fftconv.circular_fftconv3d_fp32_bhl
+
+Ops — Multi-head FFT convolutions
+---------------------------------
+
+Multi-head variants used by Hyena-style mixers, including low-rank
+factorizations.
+
+.. autosummary::
+   :toctree: generated/
+   :template: function_template.rst
+
+   ~ops.fftconv_multihead.fftconv2d_multihead_bhl
+   ~ops.fftconv_multihead.fftconv2d_multihead_lowrank_bhl
+   ~ops.fftconv_multihead.fftconv2d_multihead_circular_bhl
+   ~ops.fftconv_multihead.fftconv2d_multihead_lowrank_circular_bhl
+
+Ops — Chunking utilities
+------------------------
+
+Helpers to bound the FFT working-set memory by processing along the
+sequence axis in chunks.
+
+.. autosummary::
+   :toctree: generated/
+   :template: function_template.rst
+
+   ~ops.fftconv_chunked.enable_chunking
+   ~ops.fftconv_chunked.chunking_enabled
+   ~ops.fftconv_chunked.set_default_chunk_size
+   ~ops.fftconv_chunked.get_default_chunk_size
+
+Modules — Mixers
+----------------
+
+High-level PyTorch ``nn.Module`` sequence/spatial mixers.
+
+.. autosummary::
+   :toctree: generated/
+   :template: class_template.rst
+
+   ~modules.hyena_nd.Hyena
+   ~modules.mamba_nd.Mamba
+   ~modules.attention.Attention
+
+Modules — Convolutions
+----------------------
+
+.. autosummary::
+   :toctree: generated/
+   :template: class_template.rst
+
+   ~modules.causal_conv1d.CausalConv1D

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -69,6 +69,7 @@ autodoc_mock_imports = [
     "einops",
     "megatron",
     "megatron.core",
+    "omegaconf",
 ]
 
 add_module_names = False

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -67,6 +67,8 @@ autodoc_mock_imports = [
     "dali",
     "nvidia.dali",
     "einops",
+    "megatron",
+    "megatron.core",
 ]
 
 add_module_names = False

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,0 +1,162 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Configuration file for the Sphinx documentation builder.
+# See https://www.sphinx-doc.org/en/master/usage/configuration.html
+
+import os
+import re as _re
+import sys
+
+
+sys.path.insert(0, os.path.abspath(".."))
+
+github_version = os.environ.get("GITHUB_REF_NAME") or os.environ.get("CI_COMMIT_REF_NAME") or "main"
+
+# -- Project information -----------------------------------------------------
+
+project = "nvsubquadratic"
+
+
+def _read_version():
+    init_path = os.path.join(os.path.dirname(__file__), "..", "nvsubquadratic", "__init__.py")
+    for line in open(init_path):
+        if line.startswith("__version__"):
+            return line.split("=", 1)[1].strip().strip('"').strip("'")
+    return "0.0.0"
+
+
+version = _read_version()
+release = version
+
+# -- General configuration ---------------------------------------------------
+
+extensions = [
+    "myst_parser",
+    "sphinx.ext.autodoc",
+    "sphinx.ext.napoleon",
+    "sphinx.ext.intersphinx",
+    "sphinx.ext.autosummary",
+    "sphinx.ext.extlinks",
+    "sphinx.ext.githubpages",
+    "sphinx.ext.doctest",
+    "sphinx_copybutton",
+    "sphinx.ext.mathjax",
+]
+
+templates_path = ["_templates"]
+
+autodoc_typehints = "description"
+autodoc_preserve_defaults = True
+
+autodoc_default_options = {
+    "members": True,
+    "member-order": "bysource",
+    "special-members": "__init__",
+    "undoc-members": False,
+    "exclude-members": "__weakref__",
+}
+
+autodoc_mock_imports = [
+    "subquadratic_ops_torch",
+    "subquadratic_ops_torch._ext",
+    "quack",
+    "quack_kernels",
+    "apex",
+    "flash_attn",
+    "dali",
+    "nvidia.dali",
+    "einops",
+]
+
+add_module_names = False
+
+intersphinx_mapping = {
+    "python": ("https://docs.python.org/3", None),
+    "numpy": ("https://numpy.org/doc/stable", None),
+    "pytorch": ("https://docs.pytorch.org/docs/stable", None),
+    "subquadratic_ops_torch": (
+        "https://nvidia-digital-bio.github.io/subquadraticOps-docs/",
+        None,
+    ),
+}
+
+_gh_repo = "https://github.com/NVIDIA-Digital-Bio/nvSubquadratic-private"
+_gh_blob_base = f"{_gh_repo}/blob/{github_version}"
+
+extlinks = {
+    "subq-ops": (
+        "https://nvidia-digital-bio.github.io/subquadraticOps-docs/%s",
+        "subquadratic-ops: %s",
+    ),
+    "ghsrc": (
+        f"{_gh_blob_base}/%s",
+        "%s",
+    ),
+}
+
+source_suffix = {
+    ".rst": "restructuredtext",
+    ".md": "markdown",
+}
+
+myst_enable_extensions = [
+    "amsmath",
+    "dollarmath",
+    "deflist",
+    "colon_fence",
+]
+
+doctest_global_setup = """
+from typing import Any
+import numpy as np
+"""
+
+exclude_patterns = ["_build", "Thumbs.db", ".DS_Store", "_templates/**"]
+
+copybutton_prompt_text = r">>> |\.\.\. |\$ "
+copybutton_prompt_is_regexp = True
+
+# -- Options for HTML output -------------------------------------------------
+
+html_theme = "nvidia_sphinx_theme"
+html_title = f"nvsubquadratic {version}"
+html_show_sphinx = False
+html_static_path = ["_static"]
+html_css_files = [
+    "custom.css",
+]
+html_context = {
+    "github_user": "NVIDIA-Digital-Bio",
+    "github_repo": "nvSubquadratic-private",
+    "github_version": github_version,
+    "doc_path": "docs",
+}
+html_theme_options = {
+    "secondary_sidebar_items": ["page-toc"],
+    "copyright_override": {"start": 2025},
+    "pygments_light_style": "tango",
+    "pygments_dark_style": "monokai",
+    "footer_links": {},
+}
+
+
+_REL_REPO_LINK = _re.compile(r"\]\((?:\.\./)+([A-Za-z0-9_][^)]*)\)")
+
+
+def _rewrite_repo_links(app, docname, source):
+    """Rewrite markdown links like [text](../../foo/bar.py) to absolute GitHub URLs.
+
+    Preserves intra-docs relative links (no leading ../) and external URLs. Lets
+    the source markdown stay readable on GitHub web while the rendered HTML
+    points at the right blob URL.
+    """
+    text = source[0]
+    new = _REL_REPO_LINK.sub(rf"]({_gh_blob_base}/\1)", text)
+    if new != text:
+        source[0] = new
+
+
+def setup(app):
+    """Register Sphinx extensions and event handlers for this build."""
+    app.connect("source-read", _rewrite_repo_links)

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,0 +1,67 @@
+.. SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+nvSubquadratic Documentation
+============================
+
+``nvsubquadratic`` is a unified PyTorch-native library for subquadratic
+alternatives to quadratic attention. It consolidates efforts from across
+NVIDIA Research teams (nvResearch, NeMo, BioNeMo) into a single, consistent
+API. The current release supports multi-dimensional (1D, 2D, 3D) Hyena
+operators backed by optimized CUDA kernels from
+:mod:`subquadratic_ops_torch`. Hyena operators provide subquadratic
+alternatives to attention, achieving ``O(N log N)`` complexity compared with
+``O(N^2)`` for traditional attention.
+
+Installation
+------------
+
+The package is installed from source:
+
+.. code-block:: bash
+
+    pip install -e .
+
+To enable the optional fused RMSNorm kernel on Hopper / Blackwell GPUs:
+
+.. code-block:: bash
+
+    pip install -e ".[quack]"
+
+Requirements
+------------
+
+- CUDA-compatible NVIDIA GPU (Ampere or Hopper architecture)
+- CUDA Toolkit 12.0 or higher
+- Python 3.11 or higher
+
+Where to go next
+----------------
+
+- **Ops Overview** — a math primer and decision tree for the FFT
+  convolution primitives at the bottom of the stack.
+- **API Reference** — auto-generated reference for the curated public
+  surface (ops + mixer modules).
+
+Related projects
+----------------
+
+``nvsubquadratic`` is the high-level PyTorch interface; the underlying
+CUDA kernels live in a separate library:
+
+- `subquadratic-ops <https://nvidia-digital-bio.github.io/subquadraticOps-docs/>`_ —
+  optimized CUDA kernels (causal conv1d, FFT conv1d/2d, B2B causal conv1d,
+  implicit filters, rearrange) that nvSubquadratic delegates to via
+  :mod:`subquadratic_ops_torch`. Refer to its API reference for kernel-level
+  signatures, supported dtypes, and GPU-architecture coverage.
+
+.. toctree::
+   :maxdepth: 1
+   :hidden:
+
+   Overview <self>
+
+.. toctree::
+   :maxdepth: 2
+
+   Ops Overview <ops/README>
+   API Reference <api>

--- a/docs/ops/FP16_FFTCONV_DERIVATION.md
+++ b/docs/ops/FP16_FFTCONV_DERIVATION.md
@@ -12,7 +12,9 @@ half-precision (FP16) FFTs for speed and memory savings.
 
 The standard approach is:
 
-$$y = \\text{IFFT}!\\bigl(\\text{FFT}(x) \\odot \\text{FFT}(k\_{\\text{pad}})\\bigr)$$
+$$
+y ;=; \\text{IFFT}!\\bigl( \\text{FFT}(x) \\odot \\text{FFT}(k\_{\\text{pad}}) \\bigr)
+$$
 
 where $k\_{\\text{pad}}$ is **k** zero-padded to length $N$.
 
@@ -41,7 +43,11 @@ $\\text{ortho-IFFT}(\\text{ortho-FFT}(x) \\odot \\text{ortho-FFT}(k)) = y / \\sq
 We multiply by $\\sqrt{N}$ after the inverse to recover the correct
 scale:
 
-$$y = \\sqrt{N} \\cdot \\text{IFFT}_{\\text{ortho}}!\\bigl(\\text{FFT}_{\\text{ortho}}(x) \\odot \\text{FFT}_{\\text{ortho}}(k_{\\text{pad}})\\bigr)$$
+$$
+y ;=; \\sqrt{N} \\cdot \\text{IFFT}_{\\text{ortho}}!\\bigl(
+\\text{FFT}_{\\text{ortho}}(x) \\odot \\text{FFT}_{\\text{ortho}}(k_{\\text{pad}})
+\\bigr)
+$$
 
 This reduces the DC bin to $\\mu_x \\sqrt{N}$, and the DC product to
 $\\mu_x \\mu_k N$, which still overflows for large $N$.  More importantly,
@@ -54,7 +60,9 @@ cuFFT performs the $\\sqrt{N}$ scaling *after* the butterfly, not during.
 
 Remove the DC component from both signals before the FFT:
 
-$$x_c = x - \\mu_x, \\qquad k_c = k - \\mu_k$$
+$$
+x_c = x - \\mu_x, \\qquad k_c = k - \\mu_k
+$$
 
 Both centered signals have zero mean, so:
 
@@ -78,14 +86,19 @@ Define:
 
 Then the zero-padded kernel decomposes as:
 
-$$k\_{\\text{pad}} = k\_{c,\\text{pad}} + \\delta$$
+$$
+k\_{\\text{pad}} = k\_{c,\\text{pad}} + \\delta
+$$
 
 Expanding the circular convolution:
 
-$$y\[n\] = \\underbrace{(x_c * k\_{c,\\text{pad}})\[n\]}_{T_1}
-\+ \\underbrace{(x_c * \\delta)\[n\]}_{T_2}
-\+ \\underbrace{\\mu_x \\sum_m k\_{c,\\text{pad}}\[m\]}_{T_3}
-\+ \\underbrace{\\mu_x \\cdot \\mu_k \\cdot K}_{T_4}$$
+$$
+y\[n\] ;=;
+\\underbrace{(x_c * k\_{c,\\text{pad}})\[n\]}_{T_1}
+;+; \\underbrace{(x_c * \\delta)\[n\]}_{T_2}
+;+; \\underbrace{\\mu_x \\sum_m k\_{c,\\text{pad}}\[m\]}_{T_3}
+;+; \\underbrace{\\mu_x \\cdot \\mu_k \\cdot K}_{T_4}
+$$
 
 where $\*$ denotes circular convolution.
 
@@ -100,11 +113,16 @@ bins are 0, internal magnitudes are $O(\\sigma)$.  Computed via FP16 FFT.
 
 #### T2: Centering correction (1D)
 
-$$T_2\[n\] = \\sum_m x_c\[(n-m) \\bmod L\] \\cdot \\delta\[m\] = \\mu_k \\sum\_{m=0}^{K-1} x_c\[(n-m) \\bmod L\]$$
+$$
+T_2\[n\] ;=; \\sum_m x_c\[(n-m) \\bmod L\] \\cdot \\delta\[m\]
+;=; \\mu_k \\sum\_{m=0}^{K-1} x_c\[(n-m) \\bmod L\]
+$$
 
 **Case $K = L$** (kernel covers the full circle):
 
-$$T_2\[n\] = \\mu_k \\sum\_{m=0}^{L-1} x_c\[(n-m) \\bmod L\] = \\mu_k \\cdot 0 = 0$$
+$$
+T_2\[n\] ;=; \\mu_k \\sum\_{m=0}^{L-1} x_c\[(n-m) \\bmod L\] ;=; \\mu_k \\cdot 0 ;=; 0
+$$
 
 because $\\sum x_c = 0$.  **No correction needed.**
 
@@ -112,7 +130,10 @@ because $\\sum x_c = 0$.  **No correction needed.**
 
 The sum covers all positions except $m = L-1$:
 
-$$T_2\[n\] = \\mu_k !!\\sum\_{m \\ne L-1}!! x_c\[(n-m) \\bmod L\] = -\\mu_k \\cdot x_c\[(n+1) \\bmod L\]$$
+$$
+T_2\[n\] ;=; \\mu_k !!\\sum\_{m \\ne L-1}!! x_c\[(n-m) \\bmod L\]
+;=; -\\mu_k \\cdot x_c\[(n+1) \\bmod L\]
+$$
 
 This is just $-\\mu_k$ times a circular shift of $x_c$ by $-1$.
 
@@ -124,12 +145,17 @@ multiplication by the phase ramp $\\phi_s\[f\] = e^{-2\\pi i f s / L}$.
 When the kernel is centered with shift $s = -\\lfloor(K-1)/2\\rfloor$,
 the zero-padded position moves, and the correction becomes:
 
-$$T_2\[n\] = -\\mu_k \\cdot x_c\[(n - s + 1) \\bmod L\]$$
+$$
+T_2\[n\] ;=; -\\mu_k \\cdot x_c\[(n - s + 1) \\bmod L\]
+$$
 
 In frequency domain, the effective kernel spectrum (including T1 + T2)
 is:
 
-$$\\hat{k}\_{\\text{eff}}\[f\] = \\phi_s\[f\] \\cdot \\biggl(\\hat{k}_c\[f\] - \\frac{\\mu_k}{\\sqrt{L}} \\cdot \\phi_{-1}\[f\]\\biggr)$$
+$$
+\\hat{k}\_{\\text{eff}}\[f\] ;=; \\phi_s\[f\] \\cdot
+\\biggl(\\hat{k}_c\[f\] ;-; \\tfrac{\\mu_k}{\\sqrt{L}} \\cdot \\phi_{-1}\[f\]\\biggr)
+$$
 
 where $\\hat{k}_c$ is the ortho-normalized FFT of $k_c$ (zero-padded),
 and $\\phi_{-1}\[f\] = e^{2\\pi i f / L}$ is the DFT of the delta at
@@ -141,7 +167,11 @@ FFT in FP32.
 
 ### Final 1D formula
 
-$$y = \\sqrt{L};\\text{IFFT}\_{\\text{ortho}}!\\bigl(\\hat{x}_c \\odot \\hat{k}_{\\text{eff}}\\bigr) + \\mu_x \\mu_k K$$
+$$
+y ;=; \\sqrt{L},\\text{IFFT}\_{\\text{ortho}}!\\bigl(
+\\hat{x}_c \\odot \\hat{k}_{\\text{eff}}
+\\bigr) ;+; \\mu_x \\mu_k K
+$$
 
 where $\\hat{x}_c = \\text{FFT}_{\\text{ortho}}(x_c)$ is computed in FP16,
 $\\hat{k}\_{\\text{eff}}$ is assembled in FP32 (small tensor, no batch dim)
@@ -154,7 +184,10 @@ For $d$-dimensional signals of shape $N_1 \\times \\cdots \\times N_d$
 with kernel shape $K_1 \\times \\cdots \\times K_d$, the decomposition
 generalizes.  The T1 and T4 terms carry over directly:
 
-$$T_1 = \\text{circ_conv}(x_c, k\_{c,\\text{pad}}), \\qquad T_4 = \\mu_x \\mu_k \\prod_i K_i$$
+$$
+T_1 ;=; \\text{circ_conv}(x_c, k\_{c,\\text{pad}}), \\qquad
+T_4 ;=; \\mu_x \\mu_k \\prod_i K_i
+$$
 
 T3 is again zero.  **T2 becomes an inclusion-exclusion sum over
 corrected axes** — those axes where $K_i \< N_i$ (i.e., there is at
@@ -169,11 +202,18 @@ position $N_i - 1$ along axis $i$).
 
 The geometric correction in frequency domain is:
 
-$$\\text{geo}\[\\mathbf{f}\] = \\sum\_{\\emptyset \\ne S \\subseteq \\mathcal{C}} (-1)^{|S|} \\Bigl(\\prod\_{i \\in S} p_i\[f_i\]\\Bigr) \\Bigl(\\prod\_{j \\notin S} N_j\\Bigr)$$
+$$
+\\text{geo}\[\\mathbf{f}\] ;=; \\sum\_{\\emptyset \\ne S \\subseteq \\mathcal{C}}
+(-1)^{|S|} \\Bigl(\\prod\_{i \\in S} p_i\[f_i\]\\Bigr)
+\\Bigl(\\prod\_{j \\notin S} N_j\\Bigr)
+$$
 
 The corrected effective kernel spectrum is:
 
-$$\\hat{k}\_{\\text{eff}}\[\\mathbf{f}\] = \\hat{k}\_c\[\\mathbf{f}\] + \\frac{\\mu_k}{\\sqrt{N}} \\cdot \\text{geo}\[\\mathbf{f}\]$$
+$$
+\\hat{k}\_{\\text{eff}}\[\\mathbf{f}\] ;=; \\hat{k}\_c\[\\mathbf{f}\]
+;+; \\tfrac{\\mu_k}{\\sqrt{N}} \\cdot \\text{geo}\[\\mathbf{f}\]
+$$
 
 followed by the phase-ramp shift for kernel centering.
 
@@ -183,18 +223,25 @@ For a 2D signal $X \\times Y$ with kernel $K_x \\times K_y$:
 
 - If $K_x \< X$ and $K_y \< Y$ (both axes corrected):
 
-$$\\text{geo}\[f_1, f_2\] = -Y \\cdot p_x\[f_1\],\\delta\_{f_2=0} - X \\cdot \\delta\_{f_1=0},p_y\[f_2\] + p_x\[f_1\],p_y\[f_2\]$$
+  $$
+  \\text{geo}\[f_1, f_2\] ;=; -Y \\cdot p_x\[f_1\],\\delta\_{f_2=0}
+  ;-; X \\cdot \\delta\_{f_1=0},p_y\[f_2\]
+  ;+; p_x\[f_1\],p_y\[f_2\]
+  $$
 
 - If only one axis is corrected (e.g., $K_x \< X$, $K_y = Y$):
 
-$$\\text{geo}\[f_1, f_2\] = -Y \\cdot p_x\[f_1\],\\delta\_{f_2=0}$$
+  $$
+  \\text{geo}\[f_1, f_2\] ;=; -Y \\cdot p_x\[f_1\],\\delta\_{f_2=0}
+  $$
 
 ### Caching
 
-The geometric factor `geo` depends only on $(K_1, \\ldots, K_d, N_1,
-\\ldots, N_d, \\text{device})$ and is **constant** during training.  It is
-computed once and cached with an LRU policy.  Only the scalar
-$\\mu_k / \\sqrt{N}$ changes per forward call.
+The geometric factor `geo` depends only on
+$(K_1, \\ldots, K_d, N_1, \\ldots, N_d, \\text{device})$ and is
+**constant** during training.  It is computed once and cached with an
+LRU policy.  Only the scalar $\\mu_k / \\sqrt{N}$ changes per forward
+call.
 
 ## 4. Implementation Details
 

--- a/docs/ops/README.md
+++ b/docs/ops/README.md
@@ -10,17 +10,17 @@ ______________________________________________________________________
 
 A standard spatial convolution between an input `x` of length `N` and a kernel `k` of length `K`,
 
-```
-y[n] = Σ_m x[n − m] · k[m]
-```
+$$
+y\[n\] ;=; \\sum\_{m} x\[n - m\] ,\\cdot, k\[m\]
+$$
 
 costs `O(N · K)` per channel. When `K` is small (e.g. a 3×3 image kernel) that is fine. When `K` is **comparable to `N`** — the regime Hyena-style models live in, where each layer's effective receptive field can span the whole input — the spatial cost grows quadratically with sequence length.
 
 The **convolution theorem** lets us replace the spatial convolution with an element-wise product in the frequency domain:
 
-```
-y = F⁻¹( F(x) ⊙ F(k) )
-```
+$$
+y ;=; \\mathcal{F}^{-1}!\\bigl( \\mathcal{F}(x) ,\\odot, \\mathcal{F}(k) \\bigr)
+$$
 
 The two FFTs and the inverse each cost `O(N log N)`, the element-wise product is `O(N)`, and the total cost is **independent of kernel size**. That is what makes "global-kernel" convolutional sequence models subquadratic.
 
@@ -83,9 +83,9 @@ The kernel's leading dim is either `1` (shared kernel across the batch — the s
 
 Every operator accepts an optional `shortcut: [H]` tensor and computes
 
-```
-y ← y + shortcut ⊙ x
-```
+$$
+y ;\\leftarrow; y + \\mathrm{shortcut} ,\\odot, x
+$$
 
 i.e. a per-channel residual scale. This is *not* a generic skip connection — it fuses a specific algebraic shortcut that shows up repeatedly in Hyena-style gating, saving a separate kernel launch. Pass `None` if you don't need it.
 
@@ -143,3 +143,10 @@ ______________________________________________________________________
 - **[`nvsubquadratic/modules/kernels_nd.py`](../../nvsubquadratic/modules/kernels_nd.py)** — learned kernel parametrisations that produce the kernels these ops consume.
 - **[`nvsubquadratic/modules/hyena_nd.py`](../../nvsubquadratic/modules/hyena_nd.py)** — the Hyena operator, the main consumer of these ops.
 - **[`nvsubquadratic/modules/ckconv_nd.py`](../../nvsubquadratic/modules/ckconv_nd.py)** / **[`ckconv_multihead_nd.py`](../../nvsubquadratic/modules/ckconv_multihead_nd.py)** — CKConv variants that compose these primitives.
+
+```{toctree}
+:maxdepth: 1
+:caption: Further reading
+
+FP16_FFTCONV_DERIVATION
+```

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,14 @@
+# Minimal requirements to build the Sphinx documentation locally.
+#
+# Install:
+#   python3 -m pip install -r docs/requirements.txt
+#
+# Build:
+#   make -C docs html SPHINXBUILD="python3 -m sphinx"
+
+sphinx>=8.1.0
+myst-parser>=4.0.0
+sphinx-copybutton>=0.5.0
+nvidia-sphinx-theme>=0.0.9.post1
+
+numpy>=1.21

--- a/nvsubquadratic/modules/attention.py
+++ b/nvsubquadratic/modules/attention.py
@@ -14,33 +14,39 @@ from nvsubquadratic.utils import qk_norm, rope
 class Attention(torch.nn.Module):
     """Multi-head attention (support for self and cross-attention) with optional QK normalization and Rotary Positional Embeddings (RoPE).
 
-    Input / Output
+    **Input / Output:**
+
     - Accepts sequences ``[B, T, C]`` or images ``[B, H, W, C]``.
     - Returns the same leading shape with channel dimension ``C``.
 
-    Dimensions
+    **Dimensions:**
+
     - ``C`` must be divisible by ``num_heads``; per-head dim is ``D = C / num_heads``.
 
-    RoPE support
+    **RoPE support:**
+
     - 1D (sequences): applied over length ``T``; requires ``D`` even.
     - 2D (images): applied over ``(H, W)`` by splitting per-head dim into two halves
       (Y-axis, X-axis); requires ``D`` divisible by 4.
     - 3D (videos or other 3D data): applied over ``(H, W, D)`` by splitting per-head dim into three halves
       (Z-axis, X-axis, Y-axis); requires ``D`` divisible by 8.
 
-    QK normalization
+    **QK normalization:**
+
     - When enabled, queries and keys are L2-normalized per head along the last dimension.
 
-    Implementation notes
-    - Uses PyTorch scaled_dot_product_attention and prefers FlashAttention kernels when available.
+    **Implementation notes:**
 
-    Context Parallelism Limitations
-    - **WARNING**: This implementation is for **illustration and compatibility only**.
+    - Uses PyTorch ``scaled_dot_product_attention`` and prefers FlashAttention kernels when available.
+
+    **Context-parallel limitations:**
+
+    - This implementation is for **illustration and compatibility only**.
     - It uses zigzag all-gather/split for CP, which causes significant memory issues at long context
       lengths because the attention layer does not implement internal ring attention.
-    - **For production use with long contexts**, use PyTorch's standard context-parallel attention
+    - For production use with long contexts, use PyTorch's standard context-parallel attention
       blocks (e.g., as in torchtitan: https://docs.pytorch.org/tutorials/unstable/context_parallel.html).
-    - Future work: Migrate to PyTorch's standard CP attention API, which may also eliminate
+    - Future work: migrate to PyTorch's standard CP attention API, which may also eliminate
       the requirement for zigzag-style communication patterns.
 
     Args:
@@ -182,13 +188,13 @@ class Attention(torch.nn.Module):
         """Apply multi-head self-attention with optional QK-norm and RoPE.
 
         Args:
-            query: [B, *spatial_dims, hidden_dim]
-            key: [B, *spatial_dims, hidden_dim]
-            value: [B, *spatial_dims, hidden_dim]
-            cp_group: torch.distributed.ProcessGroup - Context parallel process group.
+            query: ``[B, *spatial_dims, hidden_dim]``
+            key: ``[B, *spatial_dims, hidden_dim]``
+            value: ``[B, *spatial_dims, hidden_dim]``
+            cp_group: ``torch.distributed.ProcessGroup`` — context-parallel process group.
 
         Returns:
-            out: [B, *spatial_dims, hidden_dim] (same as input)
+            out: ``[B, *spatial_dims, hidden_dim]`` (same as input)
         """
         # CP communication for self-attention (Megatron-style):
         # CP only splits sequence/spatial dimension, not hidden_dim or heads

--- a/nvsubquadratic/modules/hyena_nd.py
+++ b/nvsubquadratic/modules/hyena_nd.py
@@ -247,14 +247,14 @@ class Hyena(torch.nn.Module):
         All tensors are channel-last on entry and exit.
 
         Args:
-            query: [B, *spatial, C] query tensor (from linear projection of input).
-            key: [B, *spatial, C] key tensor.
-            value: [B, *spatial, C] value tensor.
+            query: ``[B, *spatial, C]`` query tensor (from linear projection of input).
+            key: ``[B, *spatial, C]`` key tensor.
+            value: ``[B, *spatial, C]`` value tensor.
             cp_group: Context-parallel process group.  None disables CP.
             **mixer_kwargs: Forwarded to the global conv (e.g. ``conditioning`` for FiLM).
 
         Returns:
-            [B, *spatial, C] output tensor.
+            ``[B, *spatial, C]`` output tensor.
         """
         # Reshape query, key, and value to [B, C, * spatial_dims] (Required for short convolutional projections).
         query = rearrange(query, "b ... c -> b c ...")

--- a/nvsubquadratic/ops/circular_fftconv.py
+++ b/nvsubquadratic/ops/circular_fftconv.py
@@ -305,12 +305,10 @@ def circular_fftconv1d_fp32_bhl(
 
     Circular convolution
     --------------------
-    - Spatially, circular (periodic) convolution can be written as:
-        circular_conv(x, k) = roll(irfft(rfft(x) * rfft(k)))
-    - To avoid the explicit spatial roll, we apply an equivalent frequency-domain
-      phase ramp:
-        circular_conv(x, k) = irfft(rfft(x) * rfft(k) * phase_ramp)
-      where ``phase_ramp`` has shape ``[L//2 + 1]`` and encodes the integer shift.
+    - Spatially, circular (periodic) convolution is ``circular_conv(x, k) = roll(irfft(rfft(x) * rfft(k)))``.
+    - To avoid the explicit spatial roll, we apply an equivalent frequency-domain phase ramp:
+      ``circular_conv(x, k) = irfft(rfft(x) * rfft(k) * phase_ramp)``, where ``phase_ramp``
+      has shape ``[L//2 + 1]`` and encodes the integer shift.
 
     Layout and shapes
     -----------------
@@ -401,14 +399,13 @@ def circular_fftconv2d_fp32_bhl(
 ) -> torch.Tensor:
     """2D circular FFT convolution with optional shortcut (BHL layout).
 
-    The circular convolution is computed as:
-        circular_conv(x, kernel) = roll(ifft2(fft2(x) * fft2(kernel)))
-
-    However, by using shifting on the frequency-domain phase ramp, we can compute the convolution as:
-        circular_conv(x, kernel) = ifft2(fft2(x) * fft2(kernel) * phase_ramp)
-    where phase_ramp is a complex tensor of shape (X_in, Y_in//2 + 1) with the phase ramp for the given shift.
-
-    By doing so, this makes the convolution faster and more memory efficient.
+    Spatially, the circular convolution is
+    ``circular_conv(x, kernel) = roll(ifft2(fft2(x) * fft2(kernel)))``.
+    Equivalently, by shifting via a frequency-domain phase ramp:
+    ``circular_conv(x, kernel) = ifft2(fft2(x) * fft2(kernel) * phase_ramp)``,
+    where ``phase_ramp`` is a complex tensor of shape ``(X_in, Y_in // 2 + 1)``
+    encoding the alignment shift.  This avoids the spatial roll, making the
+    convolution faster and more memory-efficient.
 
     Args:
         x: Tensor of shape (B, H, X_in, Y_in), any dtype (internally cast to float32).
@@ -484,12 +481,10 @@ def circular_fftconv3d_fp32_bhl(
 
     Circular convolution
     --------------------
-    - Spatially, circular (periodic) convolution can be written as:
-        circular_conv(x, k) = roll(irfftn(rfftn(x) * rfftn(k)))
-    - To avoid the explicit spatial roll, we apply an equivalent frequency-domain
-      phase ramp:
-        circular_conv(x, k) = irfftn(rfftn(x) * rfftn(k) * phase_ramp)
-      where ``phase_ramp`` has shape ``[X, Y, Z//2 + 1]`` and encodes the integer shifts.
+    - Spatially, circular (periodic) convolution is ``circular_conv(x, k) = roll(irfftn(rfftn(x) * rfftn(k)))``.
+    - To avoid the explicit spatial roll, we apply an equivalent frequency-domain phase ramp:
+      ``circular_conv(x, k) = irfftn(rfftn(x) * rfftn(k) * phase_ramp)``, where ``phase_ramp``
+      has shape ``[X, Y, Z//2 + 1]`` and encodes the integer shifts.
 
     Layout and shapes
     -----------------


### PR DESCRIPTION
## Summary
- Add Sphinx-based API documentation under `docs/` (autosummary + nvidia-sphinx-theme + MyST for markdown narrative).
- Curated public-API surface in `docs/api.rst` covering ops (fftconv, circular, multi-head, chunked, custom) and key mixer modules (Hyena, Mamba, Attention, CausalConv1D).
- Wire `docs/ops/README.md` and `docs/ops/FP16_FFTCONV_DERIVATION.md` from PR #117 into the toctree; intersphinx-link `subquadratic_ops_torch` to the published kernel docs.
- `source-read` hook in `conf.py` auto-rewrites `[…](../../path)` markdown links to absolute GitHub blob URLs at build time (raw markdown stays readable on GitHub web).
- Add `.github/workflows/docs.yml`: builds on push to `main` / `workflow_dispatch` and deploys to the `gh-pages` branch of this repo (peaceiris/actions-gh-pages, in-repo `GITHUB_TOKEN`).
- Add empty `nvsubquadratic/ops/__init__.py` for clean package discovery; gitignore `docs/_build/` and `docs/generated/`.

Once the repo flips to public, set **Settings → Pages → Source: gh-pages /** to serve the site at `https://nvidia-digital-bio.github.io/nvSubquadratic-private/`.

## Environment setup

Create the conda environment (required to run tests):

```bash
bash setup_conda_env.sh
conda activate nvsubquadratic
```

## Pre-commit

Run locally before pushing:

```bash
pre-commit install
pre-commit run --all-files
```

## Test plan

<!-- How did you test this? Bulleted checklist preferred. -->
